### PR TITLE
edgeTransport 2.0 release

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '219131'
+ValidationKey: '219142'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'reporttransport: Reporting package for edgeTransport'
 version: 0.0.11
-date-released: '2024-07-17'
+date-released: '2024-07-18'
 abstract: This package contains edgeTransport-specific routines to report model results.
   The main functionality is to generate transport reporting variables in MIF format
   from a given edgeTransport model run folder or REMIND input data.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: reporttransport
 Title: Reporting package for edgeTransport
 Version: 0.0.11
-Date: 2024-07-17
+Date: 2024-07-18
 Authors@R:
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"))
 Description: This package contains edgeTransport-specific routines to


### PR DESCRIPTION
Report transport reports transport variables from edgeTransport 2.0 iterative and standalone runs for multiple purposes
and offers analysis tools like transport compare scenarios.
A detailed package Vignette will follow. 