### PR TITLE
Update and fix plots for CompScen transport

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '799040'
+ValidationKey: '819385'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '999300'
+ValidationKey: '1019439'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'reporttransport: Reporting package for edgeTransport'
-version: 0.5.0
-date-released: '2024-09-20'
+version: 0.5.1
+date-released: '2024-09-23'
 abstract: This package contains edgeTransport-specific routines to report model results.
   The main functionality is to generate transport reporting variables in MIF format
   from a given edgeTransport model run folder or REMIND input data.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'reporttransport: Reporting package for edgeTransport'
-version: 0.4.0
-date-released: '2024-09-10'
+version: 0.4.1
+date-released: '2024-09-19'
 abstract: This package contains edgeTransport-specific routines to report model results.
   The main functionality is to generate transport reporting variables in MIF format
   from a given edgeTransport model run folder or REMIND input data.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: reporttransport
 Title: Reporting package for edgeTransport
-Version: 0.4.0
-Date: 2024-09-10
+Version: 0.4.1
+Date: 2024-09-19
 Authors@R:
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"))
 Description: This package contains edgeTransport-specific routines to

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: reporttransport
 Title: Reporting package for edgeTransport
-Version: 0.5.0
-Date: 2024-09-20
+Version: 0.5.1
+Date: 2024-09-23
 Authors@R:
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"))
 Description: This package contains edgeTransport-specific routines to

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reporting package for edgeTransport
 
-R package **reporttransport**, version **0.5.0**
+R package **reporttransport**, version **0.5.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/reporttransport)](https://cran.r-project.org/package=reporttransport)  [![R build status](https://github.com/pik-piam/reporttransport/workflows/check/badge.svg)](https://github.com/pik-piam/reporttransport/actions) [![codecov](https://codecov.io/gh/pik-piam/reporttransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/reporttransport) [![r-universe](https://pik-piam.r-universe.dev/badges/reporttransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -41,7 +41,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **reporttransport** in publications use:
 
-Hoppe J (2024). _reporttransport: Reporting package for edgeTransport_. R package version 0.5.0, <https://github.com/pik-piam/reporttransport>.
+Hoppe J (2024). _reporttransport: Reporting package for edgeTransport_. R package version 0.5.1, <https://github.com/pik-piam/reporttransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,7 +50,7 @@ A BibTeX entry for LaTeX users is
   title = {reporttransport: Reporting package for edgeTransport},
   author = {Johanna Hoppe},
   year = {2024},
-  note = {R package version 0.5.0},
+  note = {R package version 0.5.1},
   url = {https://github.com/pik-piam/reporttransport},
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reporting package for edgeTransport
 
-R package **reporttransport**, version **0.4.0**
+R package **reporttransport**, version **0.4.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/reporttransport)](https://cran.r-project.org/package=reporttransport)  [![R build status](https://github.com/pik-piam/reporttransport/workflows/check/badge.svg)](https://github.com/pik-piam/reporttransport/actions) [![codecov](https://codecov.io/gh/pik-piam/reporttransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/reporttransport) [![r-universe](https://pik-piam.r-universe.dev/badges/reporttransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -41,7 +41,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **reporttransport** in publications use:
 
-Hoppe J (2024). _reporttransport: Reporting package for edgeTransport_. R package version 0.4.0, <https://github.com/pik-piam/reporttransport>.
+Hoppe J (2024). _reporttransport: Reporting package for edgeTransport_. R package version 0.4.1, <https://github.com/pik-piam/reporttransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,7 +50,7 @@ A BibTeX entry for LaTeX users is
   title = {reporttransport: Reporting package for edgeTransport},
   author = {Johanna Hoppe},
   year = {2024},
-  note = {R package version 0.4.0},
+  note = {R package version 0.4.1},
   url = {https://github.com/pik-piam/reporttransport},
 }
 ```

--- a/inst/compareScenarios/cs_02_energy_services.Rmd
+++ b/inst/compareScenarios/cs_02_energy_services.Rmd
@@ -1,8 +1,24 @@
 # Energy Services
+## Passenger without bunkers
+```{r}
+tot_wobunk <- "ES|Transport edge|Pass"
+items <- c(
+    "ES|Transport|Pass|Domestic Aviation",
+    "ES|Transport|Pass|Rail|HSR",
+    "ES|Transport|Pass|Rail|non-HSR",
+    "ES|Transport|Pass|Road|Bus",
+    "ES|Transport|Pass|Road|LDV|Four Wheelers",
+    "ES|Transport|Pass|Road|LDV|Two Wheelers",
+    "ES|Transport|Pass|Non-motorized|Walk",
+    "ES|Transport|Pass|Non-motorized|Cycle"
+  )
+showAreaAndBarPlots(data, items, tot_wobunk, orderVars = "user")
+showAreaAndBarPlots(data, items, tot_wobunk, fill=TRUE, orderVars = "user")
+```
+
 ## Passenger with bunkers
 ```{r}
 tot_wbunk <- "ES|Transport|Pass with bunkers"
-tot_wobunk <- "ES|Transport edge|Pass"
 items <- c(
     "ES|Transport|Bunkers|Pass|International Aviation",
     "ES|Transport|Pass|Domestic Aviation",
@@ -15,9 +31,7 @@ items <- c(
     "ES|Transport|Pass|Non-motorized|Cycle"
   )
 showAreaAndBarPlots(data, items, tot_wbunk,  orderVars = "user")
-showAreaAndBarPlots(data, items[2:9], tot_wobunk, orderVars = "user")
 showAreaAndBarPlots(data, items, tot_wbunk, fill=TRUE, orderVars = "user")
-showAreaAndBarPlots(data, items[2:9], tot_wobunk, fill=TRUE, orderVars = "user")
 showLinePlots(data, tot_wbunk)
 walk(c( "ES|Transport|Pass|Aviation", tot_wobunk, items[1:5], "ES|Transport|Pass|Road|LDV", items[6:9]), showLinePlots, data = data)
 ```
@@ -99,10 +113,21 @@ showAreaAndBarPlots(data, items, tot, orderVars = "user")
 showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
 ```
 
+## Freight without bunkers
+```{r}
+tot_wobunk <- "ES|Transport edge|Freight"
+items <- c(
+      "ES|Transport|Freight|Domestic Shipping",
+      "ES|Transport|Freight|Rail",
+      "ES|Transport|Freight|Road"
+  )
+showAreaAndBarPlots(data, items, tot_wobunk, orderVars = "user")
+showAreaAndBarPlots(data, items, tot_wobunk, fill=TRUE, orderVars = "user")
+```
+
 ## Freight with bunkers
 ```{r}
 tot_wbunk <- "ES|Transport|Freight with bunkers"
-tot_wobunk <- "ES|Transport|Freight"
 items <- c(
       "ES|Transport|Bunkers|Freight|International Shipping",
       "ES|Transport|Freight|Domestic Shipping",
@@ -110,13 +135,10 @@ items <- c(
       "ES|Transport|Freight|Road"
   )
 showAreaAndBarPlots(data, items, tot_wbunk, orderVars = "user")
-showAreaAndBarPlots(data, items[2:4], tot_wobunk, orderVars = "user")
 showAreaAndBarPlots(data, items, tot_wbunk, fill=TRUE, orderVars = "user")
-showAreaAndBarPlots(data, items[2:4], tot_wobunk, fill=TRUE, orderVars = "user")
 showLinePlots(data, tot_wbunk)
 walk(items, showLinePlots, data=data)
 ```
-
 
 
 ## Freight per Capita

--- a/inst/compareScenarios/cs_02_energy_services.Rmd
+++ b/inst/compareScenarios/cs_02_energy_services.Rmd
@@ -1,7 +1,7 @@
 # Energy Services
 ## Passenger without bunkers
 ```{r}
-tot_wobunk <- "ES|Transport edge|Pass"
+totWoBunk <- "ES|Transport edge|Pass"
 items <- c(
     "ES|Transport|Pass|Domestic Aviation",
     "ES|Transport|Pass|Rail|HSR",
@@ -12,13 +12,13 @@ items <- c(
     "ES|Transport|Pass|Non-motorized|Walk",
     "ES|Transport|Pass|Non-motorized|Cycle"
   )
-showAreaAndBarPlots(data, items, tot_wobunk, orderVars = "user")
-showAreaAndBarPlots(data, items, tot_wobunk, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items, totWoBunk, orderVars = "user")
+showAreaAndBarPlots(data, items, totWoBunk, fill = TRUE, orderVars = "user")
 ```
 
 ## Passenger with bunkers
 ```{r}
-tot_wbunk <- "ES|Transport|Pass with bunkers"
+totBunk <- "ES|Transport|Pass with bunkers"
 items <- c(
     "ES|Transport|Bunkers|Pass|International Aviation",
     "ES|Transport|Pass|Domestic Aviation",
@@ -30,10 +30,11 @@ items <- c(
     "ES|Transport|Pass|Non-motorized|Walk",
     "ES|Transport|Pass|Non-motorized|Cycle"
   )
-showAreaAndBarPlots(data, items, tot_wbunk,  orderVars = "user")
-showAreaAndBarPlots(data, items, tot_wbunk, fill=TRUE, orderVars = "user")
-showLinePlots(data, tot_wbunk)
-walk(c( "ES|Transport|Pass|Aviation", tot_wobunk, items[1:5], "ES|Transport|Pass|Road|LDV", items[6:9]), showLinePlots, data = data)
+showAreaAndBarPlots(data, items, totBunk,  orderVars = "user")
+showAreaAndBarPlots(data, items, totBunk, fill = TRUE, orderVars = "user")
+showLinePlots(data, totBunk)
+walk(c("ES|Transport|Pass|Aviation", totWoBunk, items[1:5], "ES|Transport|Pass|Road|LDV", items[6:9]),
+     showLinePlots, data = data)
 ```
 
 ## Passenger per Capita
@@ -52,7 +53,7 @@ items <- c(
     "ES|Transport|Pass|Non-motorized|Walk pCap",
     "ES|Transport|Pass|Non-motorized|Cycle pCap"
     )
-showMultiLinePlots(data, items)    
+showMultiLinePlots(data, items)
 showMultiLinePlotsByVariable(data, items, "GDP|PPP pCap")
 walk(items, showLinePlotsByVariable, data = data, xVar = "GDP|PPP pCap")
 ```
@@ -84,7 +85,7 @@ items <- c(
   )
 
 showAreaAndBarPlots(data, items, tot, orderVars = "user")
-showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
 ## LDV 2-Wheelers by technology
@@ -92,11 +93,11 @@ showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
 tot <- "ES|Transport|Pass|Road|LDV|Two Wheelers"
 items <- c(
      "ES|Transport|Pass|Road|LDV|Two Wheelers|BEV",
-     "ES|Transport|Pass|Road|LDV|Two Wheelers|Liquids" 
+     "ES|Transport|Pass|Road|LDV|Two Wheelers|Liquids"
   )
 
 showAreaAndBarPlots(data, items, tot, orderVars = "user")
-showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
 ## Busses by technology
@@ -106,38 +107,38 @@ items <- c(
        "ES|Transport|Pass|Road|Bus|BEV",
        "ES|Transport|Pass|Road|Bus|FCEV",
        "ES|Transport|Pass|Road|Bus|Gases",
-       "ES|Transport|Pass|Road|Bus|Liquids" 
+       "ES|Transport|Pass|Road|Bus|Liquids"
   )
 
 showAreaAndBarPlots(data, items, tot, orderVars = "user")
-showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
 ## Freight without bunkers
 ```{r}
-tot_wobunk <- "ES|Transport edge|Freight"
+totWoBunk <- "ES|Transport edge|Freight"
 items <- c(
       "ES|Transport|Freight|Domestic Shipping",
       "ES|Transport|Freight|Rail",
       "ES|Transport|Freight|Road"
   )
-showAreaAndBarPlots(data, items, tot_wobunk, orderVars = "user")
-showAreaAndBarPlots(data, items, tot_wobunk, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items, totWoBunk, orderVars = "user")
+showAreaAndBarPlots(data, items, totWoBbunk, fill = TRUE, orderVars = "user")
 ```
 
 ## Freight with bunkers
 ```{r}
-tot_wbunk <- "ES|Transport|Freight with bunkers"
+totBunk <- "ES|Transport|Freight with bunkers"
 items <- c(
       "ES|Transport|Bunkers|Freight|International Shipping",
       "ES|Transport|Freight|Domestic Shipping",
       "ES|Transport|Freight|Rail",
       "ES|Transport|Freight|Road"
   )
-showAreaAndBarPlots(data, items, tot_wbunk, orderVars = "user")
-showAreaAndBarPlots(data, items, tot_wbunk, fill=TRUE, orderVars = "user")
-showLinePlots(data, tot_wbunk)
-walk(items, showLinePlots, data=data)
+showAreaAndBarPlots(data, items, totBunk, orderVars = "user")
+showAreaAndBarPlots(data, items, totBunk, fill = TRUE, orderVars = "user")
+showLinePlots(data, totBunk)
+walk(items, showLinePlots, data = data)
 ```
 
 
@@ -151,10 +152,9 @@ items <- c(
       "ES|Transport|Freight|Rail pCap",
       "ES|Transport|Freight|Road pCap"
     )
-showMultiLinePlots(data, items)    
+showMultiLinePlots(data, items)
 showMultiLinePlotsByVariable(data, items, "GDP|PPP pCap")
 walk(items, showLinePlotsByVariable, data = data, xVar = "GDP|PPP pCap")
-
 ```
 
 ## Trucks
@@ -171,7 +171,7 @@ items <- c(
   )
 
 showAreaAndBarPlots(data, items, tot, orderVars = "user")
-showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
 ### By technology
@@ -185,6 +185,6 @@ items <- c(
   )
 
 showAreaAndBarPlots(data, items, tot, orderVars = "user")
-showAreaAndBarPlots(data, items, tot, fill=TRUE, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 

--- a/inst/compareScenarios/cs_04_stock_and_sales.Rmd
+++ b/inst/compareScenarios/cs_04_stock_and_sales.Rmd
@@ -4,7 +4,7 @@
 ```{r}
 tot <- "Stock|Transport|Pass|Road|LDV"
 items <- c("Stock|Transport|Pass|Road|LDV|Four Wheelers|Large|Large Car",
-           "Stock|Transport|Pass|Road|LDV|Four Wheelers|Large|LargeCar and SUV",
+           "Stock|Transport|Pass|Road|LDV|Four Wheelers|Large|Large Car and SUV",
            "Stock|Transport|Pass|Road|LDV|Four Wheelers|Large|Van",
            "Stock|Transport|Pass|Road|LDV|Four Wheelers|Medium|Compact Car",
            "Stock|Transport|Pass|Road|LDV|Four Wheelers|Medium|Midsize Car",
@@ -15,7 +15,7 @@ showAreaAndBarPlots(data, items, tot, orderVars = "user")
 showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
-## LDV Sales by vehicle size
+## LDV Sales by vehicle size 
 ```{r}
 tot <- "Sales|Transport|Pass|Road|LDV"
 items <- c("Sales|Transport|Pass|Road|LDV|Four Wheelers|Large|Large Car",
@@ -32,6 +32,30 @@ showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 
 ## LDV Stock by technology
 ```{r}
+tot <- "Stock|Transport|Pass|Road|LDV"
+items <- c("Stock|Transport|Pass|Road|LDV|BEV",
+           "Stock|Transport|Pass|Road|LDV|FCEV",
+           "Stock|Transport|Pass|Road|LDV|Hybrid electric",
+           "Stock|Transport|Pass|Road|LDV|Liquids",
+           "Stock|Transport|Pass|Road|LDV|Gases")
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
+```
+
+## LDV Sales by technology
+```{r}
+tot <- "Sales|Transport|Pass|Road|LDV"
+items <- c("Sales|Transport|Pass|Road|LDV|BEV",
+           "Sales|Transport|Pass|Road|LDV|FCEV",
+           "Sales|Transport|Pass|Road|LDV|Hybrid electric",
+           "Sales|Transport|Pass|Road|LDV|Liquids",
+           "Sales|Transport|Pass|Road|LDV|Gases")
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
+```
+
+## LDV Stock by technology - Subcompact Car
+```{r}
 tot <- "Stock|Transport|Pass|Road|LDV|Four Wheelers|Small|Subcompact Car"
 items <- c("Stock|Transport|Pass|Road|LDV|Four Wheelers|Small|Subcompact Car|BEV",
            "Stock|Transport|Pass|Road|LDV|Four Wheelers|Small|Subcompact Car|FCEV",
@@ -42,7 +66,7 @@ showAreaAndBarPlots(data, items, tot, orderVars = "user")
 showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
-## LDV Sales by technology
+## LDV Sales by technology - Subcompact Car
 ```{r}
 tot <- "Sales|Transport|Pass|Road|LDV|Four Wheelers|Small|Subcompact Car"
 items <- c("Sales|Transport|Pass|Road|LDV|Four Wheelers|Small|Subcompact Car|BEV",
@@ -54,7 +78,7 @@ showAreaAndBarPlots(data, items, tot, orderVars = "user")
 showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
-## LDV Stock by technology
+## LDV Stock by technology - Large Car and SUV
 ```{r}
 tot <- "Stock|Transport|Pass|Road|LDV|Four Wheelers|Large|Large Car and SUV"
 items <- c("Stock|Transport|Pass|Road|LDV|Four Wheelers|Large|Large Car and SUV|BEV",
@@ -66,7 +90,7 @@ showAreaAndBarPlots(data, items, tot, orderVars = "user")
 showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
-## LDV Sales by technology
+## LDV Sales by technology - Large Car and SUV
 ```{r}
 tot <- "Sales|Transport|Pass|Road|LDV|Four Wheelers|Large|Large Car and SUV"
 items <- c("Sales|Transport|Pass|Road|LDV|Four Wheelers|Large|Large Car and SUV|BEV",
@@ -78,7 +102,7 @@ showAreaAndBarPlots(data, items, tot, orderVars = "user")
 showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
-## Busses
+## Busses Stock by technology
 ```{r}
 tot <- "Stock|Transport|Pass|Road|Bus"
 items <- c("Stock|Transport|Pass|Road|Bus|BEV",
@@ -113,7 +137,29 @@ showAreaAndBarPlots(data, items, tot, orderVars = "user")
 showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
-## Small Truck stock by technology
+## Truck stock by technology
+```{r}
+tot <- "Stock|Transport|Freight|Road"
+items <- c("Stock|Transport|Freight|Road|BEV",
+           "Stock|Transport|Freight|Road|FCEV",
+           "Stock|Transport|Freight|Road|Liquids",
+           "Stock|Transport|Freight|Road|Gases")
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
+```
+
+## Truck sales by technology
+```{r}
+tot <- "Sales|Transport|Freight|Road"
+items <- c("Sales|Transport|Freight|Road|BEV",
+           "Sales|Transport|Freight|Road|FCEV",
+           "Sales|Transport|Freight|Road|Liquids",
+           "Sales|Transport|Freight|Road|Gases")
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
+```
+
+## Truck stock by technology - small
 ```{r}
 tot <- "Stock|Transport|Freight|Road|Light|Truck(0-3_5t)"
 items <- c("Stock|Transport|Freight|Road|Light|Truck(0-3_5t)|BEV",
@@ -124,7 +170,7 @@ showAreaAndBarPlots(data, items, tot, orderVars = "user")
 showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
-## Small Truck sales by technology
+## Truck sales by technology - small
 ```{r}
 tot <- "Sales|Transport|Freight|Road|Light|Truck(0-3_5t)"
 items <- c("Sales|Transport|Freight|Road|Light|Truck(0-3_5t)|BEV",
@@ -135,7 +181,7 @@ showAreaAndBarPlots(data, items, tot, orderVars = "user")
 showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
-## Large Truck stock by technology
+## Truck stock by technology - large
 ```{r}
 tot <- "Stock|Transport|Freight|Road|Heavy|Truck(40t)"
 items <- c("Stock|Transport|Freight|Road|Heavy|Truck(40t)|BEV",
@@ -146,7 +192,7 @@ showAreaAndBarPlots(data, items, tot, orderVars = "user")
 showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
-## Large Truck sales by technology
+## Truck sales by technology - large
 ```{r}
 tot <- "Sales|Transport|Freight|Road|Heavy|Truck(40t)"
 items <- c("Sales|Transport|Freight|Road|Heavy|Truck(40t)|BEV",


### PR DESCRIPTION
Energy services: 
- Added sub headers for freight and passenger transport without bunkers
- Fixed total for freight without bunkers
- Fixed linter warnings, renamed Variables in CamelCase

Sock and sales:
- Fixed missing values in LDV stock (typo in variable)
- Added aggregated plots for sales/shares by technology (all sizes)
- Added size labels to plot headers