### PR TITLE
Adjust reporting

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1019439'
+ValidationKey: '1200720'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1200720'
+ValidationKey: '1201560'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
@@ -6,3 +6,4 @@ AcceptedWarnings:
 AcceptedNotes: 'Undefined global functions or variables:'
 allowLinterWarnings: yes
 enforceVersionUpdate: no
+skipCoverage: no

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -63,6 +63,6 @@ jobs:
         shell: Rscript {0}
         run: |
           nonDummyTests <- setdiff(list.files("./tests/testthat/"), c("test-dummy.R", "_snaps"))
-          if(length(nonDummyTests) > 0) covr::codecov(quiet = FALSE)
+          if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) covr::codecov(quiet = FALSE)
         env:
           NOT_CRAN: "true"

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,14 +23,14 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
-            any::lucode2
-            any::covr
-            any::madrat
-            any::magclass
-            any::citation
-            any::gms
-            any::goxygen
-            any::GDPuc
+            lucode2
+            covr
+            madrat
+            magclass
+            citation
+            gms
+            goxygen
+            GDPuc
           # piam packages also available on CRAN (madrat, magclass, citation,
           # gms, goxygen, GDPuc) will usually have an outdated binary version
           # available; by using extra-packages we get the newest version

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: If you use this software, please cite it using the metadata from this f
 type: software
 title: 'reporttransport: Reporting package for edgeTransport'
 version: 0.6.0
-date-released: '2024-10-16'
+date-released: '2024-10-30'
 abstract: This package contains edgeTransport-specific routines to report model results.
   The main functionality is to generate transport reporting variables in MIF format
   from a given edgeTransport model run folder or REMIND input data.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'reporttransport: Reporting package for edgeTransport'
-version: 0.5.1
-date-released: '2024-09-23'
+version: 0.6.0
+date-released: '2024-10-16'
 abstract: This package contains edgeTransport-specific routines to report model results.
   The main functionality is to generate transport reporting variables in MIF format
   from a given edgeTransport model run folder or REMIND input data.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: reporttransport
 Title: Reporting package for edgeTransport
-Version: 0.5.1
-Date: 2024-09-23
+Version: 0.6.0
+Date: 2024-10-16
 Authors@R:
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"))
 Description: This package contains edgeTransport-specific routines to

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: reporttransport
 Title: Reporting package for edgeTransport
 Version: 0.6.0
-Date: 2024-10-16
+Date: 2024-10-30
 Authors@R:
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"))
 Description: This package contains edgeTransport-specific routines to

--- a/R/aggregateVariables.R
+++ b/R/aggregateVariables.R
@@ -75,6 +75,7 @@ aggregateVariables <- function(vars, mapAggregation, weight = NULL) {
   # Test for duplicated entries to prevent double counting in the aggregation
   test <- copy(vars)
   test[, value := NULL]
+
   if (anyDuplicated(test)) stop("Variables for aggregation contain duplicates.
                                 Check reportEdgeTransport() to prevent double counting")
 
@@ -95,6 +96,13 @@ aggregateVariables <- function(vars, mapAggregation, weight = NULL) {
     weight[, c("variable", "unit") := NULL]
     setnames(weight, "value", "weight")
   }
+
+  # Exclude vars that are not aggregated and create solely the variable entry
+  exclude <- c("Load factor", "Load factor raw", "Preference|FV", "Preference|S1S", "Preference|S2S1",
+               "Preference|S3S2", "Preference|VS3", "TCO sales Operating costs (total non-fuel)", "TCO sales Fuel costs", "TCO sales Capital costs", "Time value costs",
+               "Annual mileage", "Energy intensity sales", "Energy intensity sales raw", "Purchase Price")
+  aggregatedvars <- createVariableEntry(vars[variable %in% exclude], aggrOrder)
+  vars <- vars[!variable %in% exclude]
 
   # Aggregate each level of the decision tree --------------------------------------------------------------------
   for (i in seq(0, length(aggrOrder) - 1)) {
@@ -135,7 +143,7 @@ aggregateVariables <- function(vars, mapAggregation, weight = NULL) {
     }
   }
 
-  exclude <- c("Sales", "Vintages", "Stock", "Load factor")
+  exclude <- c("Sales", "Vintages", "Stock")
   varsForFurtherAggregation <- vars[!variable %in% exclude]
 
   # Aggregate Pass with bunkers --------------------------------------------------------------------

--- a/R/aggregateVariables.R
+++ b/R/aggregateVariables.R
@@ -100,7 +100,7 @@ aggregateVariables <- function(vars, mapAggregation, weight = NULL) {
   # Exclude vars that are not aggregated and create solely the variable entry
   exclude <- c("Load factor", "Load factor raw", "Preference|FV", "Preference|S1S", "Preference|S2S1",
                "Preference|S3S2", "Preference|VS3", "TCO sales Operating costs (total non-fuel)", "TCO sales Fuel costs", "TCO sales Capital costs", "Time value costs",
-               "Annual mileage", "Energy intensity sales", "Energy intensity sales raw", "Purchase Price")
+               "Annual mileage", "Energy intensity sales", "Energy intensity (raw)", "Purchase Price", "Load factor (raw)")
 
   aggregatedvars <- createVariableEntry(vars[variable %in% exclude | grepl(".*Iteration.*", variable)], aggrOrder)
   vars <- vars[!(variable %in% exclude | grepl(".*Iteration.*", variable))]
@@ -292,8 +292,8 @@ aggregateVariables <- function(vars, mapAggregation, weight = NULL) {
   aggregatedvars <- rbind(aggregatedvars, aggrvars)
 
   if (anyNA(aggregatedvars)) stop("Output variable contains NAs.
-                                  Please check reportAndAggregatedMIF()")
+                                  Please check aggregateVariables()")
   if (anyDuplicated(aggregatedvars[, c("region", "period", "variable")])) stop("Output variable contains Duplicates.
-                                         Please check reportAndAggregatedMIF()")
+                                         Please check aggregateVariables()")
   return(aggregatedvars)
 }

--- a/R/aggregateVariables.R
+++ b/R/aggregateVariables.R
@@ -101,8 +101,9 @@ aggregateVariables <- function(vars, mapAggregation, weight = NULL) {
   exclude <- c("Load factor", "Load factor raw", "Preference|FV", "Preference|S1S", "Preference|S2S1",
                "Preference|S3S2", "Preference|VS3", "TCO sales Operating costs (total non-fuel)", "TCO sales Fuel costs", "TCO sales Capital costs", "Time value costs",
                "Annual mileage", "Energy intensity sales", "Energy intensity sales raw", "Purchase Price")
-  aggregatedvars <- createVariableEntry(vars[variable %in% exclude], aggrOrder)
-  vars <- vars[!variable %in% exclude]
+
+  aggregatedvars <- createVariableEntry(vars[variable %in% exclude | grepl(".*Iteration.*", variable)], aggrOrder)
+  vars <- vars[!(variable %in% exclude | grepl(".*Iteration.*", variable))]
 
   # Aggregate each level of the decision tree --------------------------------------------------------------------
   for (i in seq(0, length(aggrOrder) - 1)) {

--- a/R/convertToMIF.R
+++ b/R/convertToMIF.R
@@ -123,17 +123,17 @@ convertToMIF <- function(vars, GDPMER, helpers, scenario, model, gdx,  isTranspo
     noAggregationvars <- rbind(rbindlist(vars$int[c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE),
                                rbindlist(regSubsetDataInt[c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE),
                                rbindlist(worldDataInt[c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE),
-                               rbindlist(vars$ext[c("GDPppp", "population")], fill = TRUE, use.names = TRUE),
-                               rbindlist(regSubsetDataExt[c("GDPppp", "population")], fill = TRUE, use.names = TRUE),
-                               rbindlist(worldDataExt[c("GDPppp", "population")], fill = TRUE, use.names = TRUE))
+                               rbindlist(vars$ext[c("GDPppp", "population", "GDPMER")], fill = TRUE, use.names = TRUE),
+                               rbindlist(regSubsetDataExt[c("GDPppp", "population", "GDPMER")], fill = TRUE, use.names = TRUE),
+                               rbindlist(worldDataExt[c("GDPppp", "population", "GDPMER")], fill = TRUE, use.names = TRUE))
 
     varsToMIFint <- rbind(rbindlist(vars$int[!names(vars$int) %in% c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE),
                           rbindlist(regSubsetDataInt[!names(regSubsetDataInt) %in% c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE),
                           rbindlist(worldDataInt[!names(worldDataInt) %in% c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE))
 
-    varsToMIFext <- rbind(rbindlist(vars$ext[!names(vars$ext) %in% c("GDPppp", "population")], fill = TRUE, use.names = TRUE),
-                          rbindlist(regSubsetDataExt[!names(regSubsetDataExt) %in% c("GDPppp", "population")], fill = TRUE, use.names = TRUE),
-                          rbindlist(worldDataExt[!names(worldDataExt) %in% c("GDPppp", "population")], fill = TRUE, use.names = TRUE))
+    varsToMIFext <- rbind(rbindlist(vars$ext[!names(vars$ext) %in% c("GDPppp", "population", "GDPMER")], fill = TRUE, use.names = TRUE),
+                          rbindlist(regSubsetDataExt[!names(regSubsetDataExt) %in% c("GDPppp", "population", "GDPMER")], fill = TRUE, use.names = TRUE),
+                          rbindlist(worldDataExt[!names(worldDataExt) %in% c("GDPppp", "population", "GDPMER")], fill = TRUE, use.names = TRUE))
   }
 
   # Apply variable naming convention----------------------------------------------------------

--- a/R/convertToMIF.R
+++ b/R/convertToMIF.R
@@ -47,6 +47,10 @@ convertToMIF <- function(vars, GDPMER, helpers, scenario, model, gdx,  isTranspo
     return(varsNew)
   }
 
+  noAggregationvars <- rbindlist(vars$int[c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE)
+  varsToMIFint <- rbindlist(vars$int[!names(vars$int) %in% c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE)
+  varsToMIFext <- rbindlist(vars$ext[!names(vars$ext) %in% c("GDPppp", "population", "GDPMER")], fill = TRUE, use.names = TRUE)
+
   # Regional aggregation----------------------------------------------------------------------
   ## Aggregation to world is always supplied
   mapWorld <- unique(vars$ext[[1]][, c("region")])[, aggrReg := "World"]
@@ -120,18 +124,18 @@ convertToMIF <- function(vars, GDPMER, helpers, scenario, model, gdx,  isTranspo
       setnames(regSubsetDataInt, "aggrReg", "region")
       return(regSubsetDataInt)}, regSubsetMap, weight)
 
-    noAggregationvars <- rbind(rbindlist(vars$int[c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE),
+    noAggregationvars <- rbind(noAggregationvars,
                                rbindlist(regSubsetDataInt[c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE),
                                rbindlist(worldDataInt[c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE),
                                rbindlist(vars$ext[c("GDPppp", "population", "GDPMER")], fill = TRUE, use.names = TRUE),
                                rbindlist(regSubsetDataExt[c("GDPppp", "population", "GDPMER")], fill = TRUE, use.names = TRUE),
                                rbindlist(worldDataExt[c("GDPppp", "population", "GDPMER")], fill = TRUE, use.names = TRUE))
 
-    varsToMIFint <- rbind(rbindlist(vars$int[!names(vars$int) %in% c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE),
+    varsToMIFint <- rbind(varsToMIFint,
                           rbindlist(regSubsetDataInt[!names(regSubsetDataInt) %in% c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE),
                           rbindlist(worldDataInt[!names(worldDataInt) %in% c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE))
 
-    varsToMIFext <- rbind(rbindlist(vars$ext[!names(vars$ext) %in% c("GDPppp", "population", "GDPMER")], fill = TRUE, use.names = TRUE),
+    varsToMIFext <- rbind(varsToMIFext,
                           rbindlist(regSubsetDataExt[!names(regSubsetDataExt) %in% c("GDPppp", "population", "GDPMER")], fill = TRUE, use.names = TRUE),
                           rbindlist(worldDataExt[!names(worldDataExt) %in% c("GDPppp", "population", "GDPMER")], fill = TRUE, use.names = TRUE))
   }

--- a/R/convertToMIF.R
+++ b/R/convertToMIF.R
@@ -22,6 +22,7 @@ convertToMIF <- function(vars, GDPMER, helpers, scenario, model, gdx,  isTranspo
   applyReportingNames <- function(vars, mapNames) {
 
     rename <- function(columns, mapNames) {
+
       dt <- data.table(name = c(columns))
       dt[, rownum := .I]
       dt <- merge(dt, mapNames, by = "name", allow.cartesian = TRUE, all.x = TRUE)
@@ -29,6 +30,7 @@ convertToMIF <- function(vars, GDPMER, helpers, scenario, model, gdx,  isTranspo
       setkey(dt, "rownum")
       dt <- dt[!is.na(reportName), name := reportName]
       dt[grepl(".*tmp", name), name := NA]
+      dt[name == "", name := NA]
       dt[!is.na(name), name := paste0("|", name)]
 
       return(dt$name)
@@ -45,42 +47,42 @@ convertToMIF <- function(vars, GDPMER, helpers, scenario, model, gdx,  isTranspo
     return(varsNew)
   }
 
-  # Use ES demand as weight to aggregate over modes-------------------------------------------
-  varsToMIFext <- vars$ext[!names(vars$ext) %in% c("GDPppp", "population")]
-  noAggregationvars <- vars$ext[c("GDPppp","population")]
-  varsToMIFext <- rbindlist(varsToMIFext, fill = TRUE, use.names = TRUE)
-  varsToMIFint <- rbindlist(vars$int, fill = TRUE, use.names = TRUE)
-
-  # Prepare vars that are not aggregated over modes
-  if (!is.null(noAggregationvars$GDPppp)){
-    noAggregationvars$GDPppp[, variable := "GDP|PPP"][, value := value * 1e-3][, unit := "billion constant 2017 Int$PPP"]
-    noAggregationvars$population[, variable := "Population"][, unit := "million"]
-    noAggregationvars <- rbindlist(noAggregationvars, fill = TRUE, use.names = TRUE)
-  }
-
-  # Apply variable naming convention----------------------------------------------------------
-  varsToMIFext <- applyReportingNames(varsToMIFext, helpers$reportingNames)
-  varsToMIFint[, fuel := NA]
-  varsToMIFint <- applyReportingNames(varsToMIFint, helpers$reportingNames)
-
   # Regional aggregation----------------------------------------------------------------------
   ## Aggregation to world is always supplied
-  mapWorld <- unique(varsToMIFext[, c("region")])[, aggrReg := "World"]
-  worldDataExt <- as.data.table(aggregate_map(varsToMIFext, mapWorld, by = "region"))
-  if (!is.null(noAggregationvars$GDPppp)) worldDatanoAggregationvars <- as.data.table(aggregate_map(noAggregationvars, mapWorld, by = "region"))
-  weight <- copy(varsToMIFext[variable == "ES"])
-  weight[, c("variable", "unit", "fuel") := NULL]
+  mapWorld <- unique(vars$ext[[1]][, c("region")])[, aggrReg := "World"]
+  worldDataExt <- lapply(vars$ext, function(x, mapWorld) as.data.table(aggregate_map(x, mapWorld, by = "region")), mapWorld)
+
+  weight <- copy(vars$ext$GDPppp)
+  weight[, c("variable", "unit") := NULL]
   setnames(weight, "value", "weight")
-  weightedInt <- merge(weight,varsToMIFint, by = intersect(names(varsToMIFint), names(weight)), all.x = TRUE)
-  byCols <- names(weightedInt)
-  byCols <- byCols[!byCols %in% c("region", "value", "weight")]
-  weightedInt[, sum := sum(weight), by = eval(byCols)]
-  weightedInt[sum == 0, weight := 1, by = eval(byCols)][, sum := NULL]
-  worldDataInt <- weightedInt[, .(value = sum(value * (weight / sum(weight)))), by = eval(byCols)]
-  worldDataInt[, region := "World"]
-  varsToMIFint <- rbind(varsToMIFint, worldDataInt)
-  varsToMIFext <- rbind(varsToMIFext, worldDataExt)
-  if (!is.null(noAggregationvars$GDPppp)) noAggregationvars <- rbind(noAggregationvars, worldDatanoAggregationvars)
+
+  #split shareweights
+  if (!is.null(vars$int$scenScpecPrefTrends)) {
+    Preferences <- list(
+      PrefrenceFV = vars$int$scenScpecPrefTrends[variable == "Preference|FV"],
+      PrefrenceS1S = vars$int$scenScpecPrefTrends[variable == "Preference|S1S"],
+      PrefrenceS2S1 = vars$int$scenScpecPrefTrends[variable == "Preference|S2S1"],
+      PrefrenceS3S2 = vars$int$scenScpecPrefTrends[variable == "Preference|S3S2"],
+      PrefrenceVS3 = vars$int$scenScpecPrefTrends[variable == "Preference|VS3"]
+    )
+    vars$int <- vars$int[!names(vars$int) == "scenScpecPrefTrends"]
+    vars$int <- append(vars$int, Preferences)
+  }
+
+  worldDataInt <- lapply(vars$int, function(x, weight) {
+    byCols <- names(x)
+    #sharweights include empty columns
+    emptyColumns <- names(vars$int)[sapply(vars$int, function(x) all(is.na(x) | x == ""))]
+    byCols <- byCols[!byCols %in% c("value") & byCols %in% names(weight) & !byCols %in% emptyColumns]
+    weight <- weight[, .(weight = sum(weight)), by = eval(byCols)]
+    weightedInt <- merge(weight, x, by = intersect(names(x), names(weight)), all.x = TRUE)
+    byCols <- names(weightedInt)
+    byCols <- byCols[!byCols %in% c("region", "value", "weight")]
+    weightedInt[, sum := sum(weight), by = eval(byCols)]
+    weightedInt[sum == 0, weight := 1, by = eval(byCols)][, sum := NULL]
+    worldDataInt <- weightedInt[, .(value = sum(value * (weight / sum(weight)))), by = eval(byCols)]
+    worldDataInt[, region := "World"]
+    return(worldDataInt)}, weight)
 
   ## Additional regions
   ## if regionSubsetList != NULL -> gdx provides 21 region resolution
@@ -99,33 +101,50 @@ convertToMIF <- function(vars, GDPMER, helpers, scenario, model, gdx,  isTranspo
       tmp <- data.table(region = regionSubsetList[[i]], aggrReg = namesReg[i])
       regSubsetMap <- rbind(regSubsetMap, tmp)
     }
-    regSubsetDataExt <- as.data.table(aggregate_map(varsToMIFext[region %in% unique(regSubsetMap$region)],
-                                                 regSubsetMap, by = "region"))
-    if (!is.null(noAggregationvars$GDPppp)) regSubsetDataNoAggregationVars <- as.data.table(aggregate_map(noAggregationvars[region %in% unique(regSubsetMap$region)],
-                                                                  regSubsetMap, by = "region"))
-    weightedInt <- merge(varsToMIFint, regSubsetMap, by = intersect(names(varsToMIFint), names(regSubsetMap)), all.y = TRUE)
-    weightedInt <- merge(weight, weightedInt, by = intersect(names(weightedInt), names(weight)), all.y = TRUE)
-    byCols <- names(weightedInt)
-    byCols <- byCols[!byCols %in% c("region", "value", "weight")]
-    weightedInt[, sum := sum(weight), by = eval(byCols)]
-    weightedInt[sum == 0, weight := 1, by = eval(byCols)][, sum := NULL]
-    regSubsetDataInt <- weightedInt[, .(value = sum(value * (weight / sum(weight)))), by = eval(byCols)]
-    setnames(regSubsetDataInt, "aggrReg", "region")
+    regSubsetDataExt <- lapply(vars$ext, function(x, regSubsetMap) {
+      as.data.table(aggregate_map(x[region %in% unique(regSubsetMap$region)],
+                                                 regSubsetMap, by = "region"))}, regSubsetMap)
+    regSubsetDataInt <- lapply(vars$int, function(x, regSubsetMap, weight) {
+      weightedInt <- merge(x, regSubsetMap, by = intersect(names(x), names(regSubsetMap)), all.y = TRUE)
+      byCols <- names(x)
+      byCols <- byCols[!byCols %in% c("value") & byCols %in% names(weight)]
+      weight <- weight[, .(weight = sum(weight)), by = eval(byCols)]
+      weightedInt <- merge(weight, weightedInt, by = intersect(names(weightedInt), names(weight)), all.y = TRUE)
+      byCols <- names(weightedInt)
+      byCols <- byCols[!byCols %in% c("region", "value", "weight")]
+      weightedInt[, sum := sum(weight), by = eval(byCols)]
+      weightedInt[sum == 0, weight := 1, by = eval(byCols)][, sum := NULL]
+      regSubsetDataInt <- weightedInt[, .(value = sum(value * (weight / sum(weight)))), by = eval(byCols)]
+      setnames(regSubsetDataInt, "aggrReg", "region")
+      return(regSubsetDataInt)}, regSubsetMap, weight)
 
-    regSubsetDataExt <- as.data.table(aggregate_map(varsToMIFext[region %in% unique(regSubsetMap$region)],
-                                                    regSubsetMap, by = "region"))
+    noAggregationvars <- rbind(rbindlist(vars$int[c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE),
+                               rbindlist(regSubsetDataInt[c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE),
+                               rbindlist(worldDataInt[c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE),
+                               rbindlist(vars$ext[c("GDPppp", "population")], fill = TRUE, use.names = TRUE),
+                               rbindlist(regSubsetDataExt[c("GDPppp", "population")], fill = TRUE, use.names = TRUE),
+                               rbindlist(worldDataExt[c("GDPppp", "population")], fill = TRUE, use.names = TRUE))
 
-    varsToMIFint <- rbind(varsToMIFint, regSubsetDataInt)
-    varsToMIFext <- rbind(varsToMIFext, regSubsetDataExt)
-    if (!is.null(noAggregationvars$GDPppp)) noAggregationvars <- rbind(regSubsetDataNoAggregationVars, noAggregationvars)
+    varsToMIFint <- rbind(rbindlist(vars$int[!names(vars$int) %in% c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE),
+                          rbindlist(regSubsetDataInt[!names(regSubsetDataInt) %in% c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE),
+                          rbindlist(worldDataInt[!names(worldDataInt) %in% c("GDPpcPPP", "GDPpcMER")], fill = TRUE, use.names = TRUE))
+
+    varsToMIFext <- rbind(rbindlist(vars$ext[!names(vars$ext) %in% c("GDPppp", "population")], fill = TRUE, use.names = TRUE),
+                          rbindlist(regSubsetDataExt[!names(regSubsetDataExt) %in% c("GDPppp", "population")], fill = TRUE, use.names = TRUE),
+                          rbindlist(worldDataExt[!names(worldDataExt) %in% c("GDPppp", "population")], fill = TRUE, use.names = TRUE))
   }
+
+  # Apply variable naming convention----------------------------------------------------------
+  varsToMIFext <- applyReportingNames(varsToMIFext, helpers$reportingNames)
+  varsToMIFint[, fuel := NA]
+  varsToMIFint <- applyReportingNames(varsToMIFint, helpers$reportingNames)
 
   # Aggregate variables-----------------------------------------------------------------------
   toMIFext <- aggregateVariables(varsToMIFext, helpers$reportingAggregation)
   weight <- varsToMIFext[variable == "ES"]
   toMIFint <- aggregateVariables(varsToMIFint, helpers$reportingAggregation, weight)
 
-  if (!is.null(noAggregationvars$GDPppp)) {
+  if (!is.null(noAggregationvars)) {
     toMIF <- rbind(toMIFint, toMIFext, noAggregationvars)
   } else {toMIF <- rbind(toMIFint, toMIFext)}
 

--- a/R/reportAnalyticsVarSet.R
+++ b/R/reportAnalyticsVarSet.R
@@ -17,7 +17,7 @@ reportAnalyticsVarSet <- function(data, timeResReporting) {
   for (i in seq_along(data$endogenousCostsIterations)) {
     updatedEndogenousCosts[[i]] <- data$endogenousCostsIterations[[i]]$updatedEndogenousCosts
     policyMask[[i]] <- data$endogenousCostsIterations[[i]]$policyMask
-    rawEndogenousCost[[i]] <- data$endogenousCostsIterations[[i]]$rawEndogenousCost
+    rawEndogenousCost[[i]] <- data$endogenousCostsIterations[[i]]$rawEndogenousCosts
   }
 
   updatedEndogenousCosts <- rbindlist(updatedEndogenousCosts)

--- a/R/reportAnalyticsVarSet.R
+++ b/R/reportAnalyticsVarSet.R
@@ -9,23 +9,42 @@
 #' @export
 
 reportAnalyticsVarSet <- function(data, timeResReporting) {
-
   updatedEndogenousCosts <- list()
   policyMask <- list()
   rawEndogenousCost <- list()
+  allCostsFV <- list()
+  allCostsVS3 <- list()
+  allCostsS3S2 <- list()
+  allCostsS2S1 <- list()
+  allCostsS1S <- list()
 
-  for (i in seq_along(data$endogenousCostsIterations)) {
-    updatedEndogenousCosts[[i]] <- data$endogenousCostsIterations[[i]]$updatedEndogenousCosts
-    policyMask[[i]] <- data$endogenousCostsIterations[[i]]$policyMask
-    rawEndogenousCost[[i]] <- data$endogenousCostsIterations[[i]]$rawEndogenousCosts
+  endogenousCostsData <- data[names(data)[grepl("endogenousCostsIteration.*", names(data))]]
+  for (i in 1:length(endogenousCostsData)) {
+    updatedEndogenousCosts[[i]] <- endogenousCostsData[[i]]$updatedEndogenousCosts
+    policyMask[[i]] <- endogenousCostsData[[i]]$policyMask
+    rawEndogenousCost[[i]] <- endogenousCostsData[[i]]$rawEndogenousCosts
   }
 
   updatedEndogenousCosts <- rbindlist(updatedEndogenousCosts)
   policyMask <- rbindlist(policyMask)
   rawEndogenousCost <- rbindlist(rawEndogenousCost)
-  fleetVehNumbersIterations <- rbindlist(data$fleetVehNumbersIterations)
-
-  analyticsData <- list(updatedEndogenousCosts, policyMask, rawEndogenousCost, fleetVehNumbersIterations)
+  fleetVehNumbersIterations <- rbindlist(data[names(data)[grepl("fleetVehNumbersIteration[0-9]+", names(data))]])
+  costsDiscreteChoiceData <- data[names(data)[grepl("costsDiscreteChoiceIteration[0-9]+", names(data))]]
+  cols <- names(data$helpers$decisionTree)
+  for (i in 1:length(costsDiscreteChoiceData)) {
+    lapply(costsDiscreteChoiceData[[i]], function(dt, cols){
+      colsdt <- names(dt)
+      missingCols <- cols[!cols %in% intersect(colsdt, cols)]
+      if (!length(missingCols) == 0) dt[, eval(missingCols) := ""]
+    }, cols)
+    allCostsFV[[i]] <- costsDiscreteChoiceData[[i]]$allCostsFV
+    allCostsVS3[[i]] <- costsDiscreteChoiceData[[i]]$allCostsVS3
+    allCostsS3S2[[i]] <- costsDiscreteChoiceData[[i]]$allCostsS3S2
+    allCostsS2S1[[i]] <- costsDiscreteChoiceData[[i]]$allCostsS2S1
+    allCostsS1S[[i]] <- costsDiscreteChoiceData[[i]]$allCostsS1S
+  }
+  analyticsData <- list(updatedEndogenousCosts, policyMask, rawEndogenousCost, fleetVehNumbersIterations, allCostsFV,
+                        allCostsVS3, allCostsS3S2, allCostsS2S1, allCostsS1S)
 
   return(analyticsData)
 }

--- a/R/reportAnalyticsVarSet.R
+++ b/R/reportAnalyticsVarSet.R
@@ -9,6 +9,7 @@
 #' @export
 
 reportAnalyticsVarSet <- function(data, timeResReporting) {
+
   updatedEndogenousCosts <- list()
   policyMask <- list()
   rawEndogenousCost <- list()
@@ -43,8 +44,21 @@ reportAnalyticsVarSet <- function(data, timeResReporting) {
     allCostsS2S1[[i]] <- costsDiscreteChoiceData[[i]]$allCostsS2S1
     allCostsS1S[[i]] <- costsDiscreteChoiceData[[i]]$allCostsS1S
   }
-  analyticsData <- list(updatedEndogenousCosts, policyMask, rawEndogenousCost, fleetVehNumbersIterations, allCostsFV,
-                        allCostsVS3, allCostsS3S2, allCostsS2S1, allCostsS1S)
 
+  allCostsFV <- rbindlist(allCostsFV)
+  allCostsVS3 <- rbindlist(allCostsVS3)
+  allCostsS3S2 <- rbindlist(allCostsS3S2)
+  allCostsS2S1 <- rbindlist(allCostsS2S1)
+  allCostsS1S <- rbindlist(allCostsS1S)
+
+  analyticsData <- list(updatedEndogenousCosts = updatedEndogenousCosts,
+                        policyMask = policyMask,
+                        rawEndogenousCost = rawEndogenousCost,
+                        fleetVehNumbersIterations = fleetVehNumbersIterations,
+                        allCostsFV = allCostsFV,
+                        allCostsVS3 = allCostsVS3,
+                        allCostsS3S2 = allCostsS3S2,
+                        allCostsS2S1 = allCostsS2S1,
+                        allCostsS1S = allCostsS1S)
   return(analyticsData)
 }

--- a/R/reportEdgeTransport.R
+++ b/R/reportEdgeTransport.R
@@ -77,7 +77,7 @@ reportEdgeTransport <- function(folderPath = file.path(".", "EDGE-T"), data = NU
     filesToLoad <- c(filesToLoad, add[!add %in% filesToLoad])
 
     if (isTransportExtendedReported) {
-      add <- c("population", "GDPppp", "GDPpcPPP", "GDPpcMER", "annualMileage", "energyIntensityRaw",
+      add <- c("population", "GDPppp", "GDPpcPPP", "GDPpcMER","GDPMER", "annualMileage", "energyIntensityRaw",
                "loadFactorRaw", "CAPEXother", "nonFuelOPEXother", "nonFuelOPEXtrackedFleet", "subsidies",
                "timeValueCosts", "scenSpecPrefTrends", "initialIncoCosts")
       filesToLoad <- c(filesToLoad, add[!add %in% filesToLoad])

--- a/R/reportEdgeTransport.R
+++ b/R/reportEdgeTransport.R
@@ -83,7 +83,7 @@ reportEdgeTransport <- function(folderPath = file.path(".", "EDGE-T"), data = NU
       filesToLoad <- c(filesToLoad, add[!add %in% filesToLoad])
     }
     if (isAnalyticsReported) {
-      add <- c("fleetVehNumbersIteration.*", "endogenousCostsIteration.*")
+      add <- c("fleetVehNumbersIteration[0-9]+", "endogenousCostsIteration[0-9]+", "costsDiscreteChoiceIteration[0-9]+")
       filesToLoad <- c(filesToLoad, add[!add %in% filesToLoad])
     }
   }
@@ -109,13 +109,16 @@ reportEdgeTransport <- function(folderPath = file.path(".", "EDGE-T"), data = NU
     }
     data$gdxPath <- gdxPath
   }
-  filePaths <- list.files(folderPath, recursive = TRUE, full.names = TRUE)
-  pathFilesToLoad <- unlist(lapply(filesToLoad, function(x) {filePaths[grepl(paste0(x, ".RDS"), filePaths)]}))
-  itemNames <- basename(pathFilesToLoad)
-  itemNames <- sub("\\.RDS$", "", itemNames)
-  addFiles <- lapply(pathFilesToLoad, readRDS)
-  names(addFiles) <- itemNames
-  data <- c(data, addFiles)
+
+  if (length(filesToLoad) > 0) {
+    filePaths <- list.files(folderPath, recursive = TRUE, full.names = TRUE)
+    pathFilesToLoad <- unlist(lapply(filesToLoad, function(x) {filePaths[grepl(paste0(x, ".RDS"), filePaths)]}))
+    itemNames <- basename(pathFilesToLoad)
+    itemNames <- sub("\\.RDS$", "", itemNames)
+    addFiles <- lapply(pathFilesToLoad, readRDS)
+    names(addFiles) <- itemNames
+    data <- c(data, addFiles)
+  }
   #########################################################################
   ## Report output variables
   #########################################################################
@@ -177,9 +180,9 @@ reportEdgeTransport <- function(folderPath = file.path(".", "EDGE-T"), data = NU
       outputVars$int <- append(outputVars$int, extendedTransportVarSet$int)
     }
     if (isAnalyticsReported) {
-      if (!is.null(data$endogenousCostsIterations)) {
+      if (!is.null(data$endogenousCostsIteration1)) {
         analyticsVarSet <- reportAnalyticsVarSet(data = data, timeResReporting = timeResReporting)
-        outputVars$analytic <- analyticsVarSet
+        outputVars$int <- c(outputVars$int, analyticsVarSet)
       } else {
         message("Analytics data not stored in the run folder. Analytics reporting is skipped.")
       }

--- a/R/reportExtendedTransportVarSet.R
+++ b/R/reportExtendedTransportVarSet.R
@@ -39,6 +39,7 @@ reportExtendedTransportVarSet <- function(data, baseVarSet, timeResReporting) {
   data$GDPppp[, variable := "GDP|PPP"][, value := value * 1e-3][, unit := "billion constant 2017 Int$PPP"]
   data$population[, variable := "Population"][, unit := "million"]
   data$GDPpcPPP[, variable := "GDPpc|PPP"][, value := value * 1e-3][, unit := "billion constant 2017 Int$PPP"]
+  data$GDPMER[, variable := "GDP|MER"][, value := value * 1e-3][, unit := "billion constant 2017 Int$MER"]
   data$GDPpcMER[, variable := "GDPpc|MER"][, value := value * 1e-3][, unit := "billion constant 2017 Int$MER"]
 
   # Report transport input data if available
@@ -56,6 +57,7 @@ reportExtendedTransportVarSet <- function(data, baseVarSet, timeResReporting) {
   outputVarsExt <- list(fleetUEdemand = fleetUEdemand,
                         vintages      = vintages,
                         GDPppp = data$GDPppp,
+                        GDPMER = data$GDPMER,
                         population = data$population)
   outputVarsInt <- list(scenScpecPrefTrends = data$scenSpecPrefTrends[, level := NULL],
                         combinedCAPEXandOPEX = combinedCAPEXandOPEX,

--- a/R/reportExtendedTransportVarSet.R
+++ b/R/reportExtendedTransportVarSet.R
@@ -38,7 +38,6 @@ reportExtendedTransportVarSet <- function(data, baseVarSet, timeResReporting) {
 
   data$GDPppp[, variable := "GDP|PPP"][, value := value * 1e-3][, unit := "billion constant 2017 Int$PPP"]
   data$population[, variable := "Population"][, unit := "million"]
-  setnames(data$GDPpcPPP, "regionGDPpcPPP", "value", skip_absent=TRUE)
   data$GDPpcPPP[, variable := "GDPpc|PPP"][, value := value * 1e-3][, unit := "billion constant 2017 Int$PPP"]
   data$GDPpcMER[, variable := "GDPpc|MER"][, value := value * 1e-3][, unit := "billion constant 2017 Int$MER"]
 

--- a/R/reportExtendedTransportVarSet.R
+++ b/R/reportExtendedTransportVarSet.R
@@ -14,15 +14,8 @@ reportExtendedTransportVarSet <- function(data, baseVarSet, timeResReporting) {
 
   constrYear <- variable <- period <- . <- value <- NULL
 
-  # Switch from mixed time resolution to the reporting time resolution for all vars------------
-  loadFactor <- copy(data$scenSpecLoadFactor)[period %in% timeResReporting]
-  fleetFEdemand <- baseVarSet$ext$fleetFEdemand[period %in% timeResReporting]
-  fleetCost <- baseVarSet$int$fleetCost[period %in% timeResReporting]
-  population <- data$population[period %in% timeResReporting]
-  GDPppp <- data$GDPppp[period %in% timeResReporting]
-
   # Report useful energy-----------------------------------------------------------------------
-  fleetUEdemand <- reportUE(FEdemand = fleetFEdemand,
+  fleetUEdemand <- reportUE(FEdemand = baseVarSet$ext$fleetFEdemand,
                                 helpers = data$helpers)
 
   # Report vintages (stock without sales)-------------------------------------------------------
@@ -30,17 +23,53 @@ reportExtendedTransportVarSet <- function(data, baseVarSet, timeResReporting) {
   vintages[, variable := "Vintages"][, constrYear := NULL]
   cols <- names(vintages)
   vintages <- vintages[, .(value = sum(value)), by = eval(cols[!cols %in% c("value", "constrYear")])]
-  vintages <- approx_dt(vintages, timeResReporting, "period", "value", extrapolate = TRUE)
-  loadFactor <- merge(loadFactor, data$helpers$decisionTree,
-                      by = intersect(names(loadFactor), names(data$helpers$decisionTree)))
+  vintages <- approx_dt(vintages, unique(fleetUEdemand$period), "period", "value", extrapolate = TRUE)
+
+  # Report annualized TCO per pkm/tkm
+  aggregatedCAPEX <- data$combinedCAPEXandOPEX[grepl(".*Capital.*", variable)]
+  aggregatedCAPEX <- aggregatedCAPEX[, .(value = sum(value)), by = c("region", "period", "univocalName", "technology", "unit")]
+  aggregatedCAPEX[, variable := "Capital costs"]
+  combinedCAPEXandOPEX <- rbind(data$combinedCAPEXandOPEX[!grepl(".*Capital.*", variable)],
+                                aggregatedCAPEX)
+  combinedCAPEXandOPEX <- merge(combinedCAPEXandOPEX, data$helpers$decisionTree,
+                                         by = intersect(names(data$combinedCAPEXandOPEX),
+                                                        names(data$helpers$decisionTree)))
+  combinedCAPEXandOPEX[, variable := paste0("TCO sales ", variable)]
+
+  data$GDPppp[, variable := "GDP|PPP"][, value := value * 1e-3][, unit := "billion constant 2017 Int$PPP"]
+  data$population[, variable := "Population"][, unit := "million"]
+  setnames(data$GDPpcPPP, "regionGDPpcPPP", "value", skip_absent=TRUE)
+  data$GDPpcPPP[, variable := "GDPpc|PPP"][, value := value * 1e-3][, unit := "billion constant 2017 Int$PPP"]
+  data$GDPpcMER[, variable := "GDPpc|MER"][, value := value * 1e-3][, unit := "billion constant 2017 Int$MER"]
+
+  # Report transport input data if available
+  inputData <- c("CAPEXother", "nonFuelOPEXtrackedFleet", "subsidies", "timeValueCosts", "annualMileage", "scenSpecLoadFactor",
+                 "loadFactorRaw", "scenSpecEnIntensity", "energyIntensityRaw")
+  inputData <- inputData[inputData %in% names(data)]
+  inputData <- lapply(copy(data[inputData]), function(item, decisionTree) {item <- merge(item, decisionTree,
+                                                                            by = intersect(names(item),
+                                                                            names(decisionTree)), allow.cartesian = TRUE)},
+                                                                            data$helpers$decisionTree)
+  inputData$loadFactorRaw[, variable := paste0(variable, " raw")]
+  inputData$energyIntensityRaw[, variable := paste0(variable, " raw")]
 
   # Split extensive and intensive variables ---------------------------------------------------
   outputVarsExt <- list(fleetUEdemand = fleetUEdemand,
                         vintages      = vintages,
-                        population    = population,
-                        GDPppp        = GDPppp)
-  outputVarsInt <- list(loadFactor = loadFactor,
-                        fleetCost  = fleetCost)
+                        GDPppp = data$GDPppp,
+                        population = data$population)
+  outputVarsInt <- list(scenScpecPrefTrends = data$scenSpecPrefTrends[, level := NULL],
+                        combinedCAPEXandOPEX = combinedCAPEXandOPEX,
+                        CAPEXother = inputData$CAPEXother,
+                        nonFuelOPEXtrackedFleet = inputData$nonFuelOPEXtrackedFleet,
+                        timeValueCosts = inputData$timeValueCosts,
+                        annualMileage = inputData$annualMileage,
+                        loadFactor = inputData$scenSpecLoadFactor,
+                        loadFactorRaw = inputData$loadFactorRaw,
+                        energyIntensity = inputData$scenSpecEnIntensity,
+                        energyIntensityRaw = inputData$energyIntensityRaw,
+                        GDPpcPPP = data$GDPpcPPP,
+                        GDPpcMER = data$GDPpcMER)
   outputVars <- list(ext = outputVarsExt,
                      int = outputVarsInt)
   return(outputVars)

--- a/R/reportREMINDinputVarSet.R
+++ b/R/reportREMINDinputVarSet.R
@@ -44,11 +44,6 @@ reportREMINDinputVarSet <- function(fleetESdemand,
 
   DEM_scenario <- GDP_scenario <- EDGE_scenario <- value <- sumES <- variable <- univocalName <- ESdemand <- NULL
 
-  timeResReporting <- c(seq(1900,1985,5),
-    seq(1990, 2060, by = 5),
-    seq(2070, 2110, by = 10),
-    2130, 2150)
-
   ## Input data for transport module GAMS code----------------------------------------------------------------------------
 
   # See needed inputs in REMIND/modules/35_transport/edge_esm/datainput.gms

--- a/R/reportTransportVarSet.R
+++ b/R/reportTransportVarSet.R
@@ -2,34 +2,22 @@
 #'
 #' @param data List that contains the model results to report the detailed transport variable set
 #' @param baseVarSet Basic output variable set
-#' @param timeResReporting Timesteps to be reported
 #'
 #' @returns Detailed transport output variable set
 #' @author Johanna Hoppe
 #' @import data.table
 #' @export
 
-reportTransportVarSet <- function(data, baseVarSet, timeResReporting) {
+reportTransportVarSet <- function(data, baseVarSet) {
 
   fuel <- variable <- value <- constrYear <- period <- technology <- . <- ESdemand <- unit <- NULL
 
-  # Switch from mixed time resolution to the reporting time resolution for all vars------------------------
-  data$ESdemandFVsalesLevel <- data$ESdemandFVsalesLevel[period %in% timeResReporting]
-  data$fleetSizeAndComposition <- lapply(data$fleetSizeAndComposition,
-                                         FUN = function(x) x <- x[period %in% timeResReporting])
-  data$upfrontCAPEXtrackedFleet <- data$upfrontCAPEXtrackedFleet[period %in% timeResReporting]
-  fleetFEdemand <- baseVarSet$ext$fleetFEdemand[period %in% timeResReporting]
-  fleetESdemand <- baseVarSet$ext$fleetESdemand[period %in% timeResReporting]
-  fleetCost <- baseVarSet$int$fleetCost[period %in% timeResReporting]
-  fleetEnergyIntensity <- baseVarSet$int$fleetEnergyIntensity[period %in% timeResReporting]
-
   # Report liquids and gases split----------------------------------------------------------------------
-  varsFEcomposition <- fleetFEdemand[technology %in% c("Liquids", "Gases")]
+  varsFEcomposition <- baseVarSet$ext$fleetFEdemand[technology %in% c("Liquids", "Gases")]
   mixedCarrierSplit <- reportLiquidsAndGasesComposition(dtFE = varsFEcomposition,
                                                             gdxPath = data$gdxPath,
-                                                            timeResReporting = timeResReporting,
                                                             helpers = data$helpers)
-  fleetFEdemandsplittedCarriers <- copy(fleetFEdemand[!technology %in% c("Liquids", "Gases")])
+  fleetFEdemandsplittedCarriers <- copy(baseVarSet$ext$fleetFEdemand[!technology %in% c("Liquids", "Gases")])
   fleetFEdemandsplittedCarriers[, fuel := NA]
   fleetFEdemandsplittedCarriers <- rbind(fleetFEdemandsplittedCarriers, mixedCarrierSplit$splittedCarriers)
 
@@ -57,15 +45,17 @@ reportTransportVarSet <- function(data, baseVarSet, timeResReporting) {
   sales <- copy(data$fleetSizeAndComposition$fleetVehNumbersConstrYears[period == constrYear])
   sales[, variable := "Sales"][, constrYear := NULL]
   sales <- approx_dt(sales, timeResReporting, "period", "value", extrapolate = TRUE)
+  sales <- approx_dt(sales, unique(fleetEmissions$period), "period", "value", extrapolate = TRUE)
 
   # Report yearly investment costs-------------------------------------------------------------------------
-  fleetES <- copy(fleetESdemand)
+  fleetES <- copy(baseVarSet$ext$fleetESdemand)
   fleetES[, c("variable", "unit") := NULL]
   setnames(fleetES, "value", "ESdemand")
-  fleetYrlCosts <- merge(fleetCost, fleetES,
-                         by = intersect(names(fleetCost), names(fleetES)))
+  fleetYrlCosts <- merge(baseVarSet$int$fleetCost, fleetES,
+                         by = intersect(names(baseVarSet$int$fleetCost), names(fleetES)))
   fleetYrlCosts[, value := value * ESdemand][, unit := "billion US$2017/yr"][, ESdemand := NULL]
   fleetYrlCosts[variable == "Capital costs", variable := "Annualized fleet investments"]
+
   fleetYrlCosts[variable == "Operating costs (total non-fuel)",
                 variable := "Operating costs fleet (total non-fuel)"]
   fleetYrlCosts[variable == "Fuel costs",
@@ -80,20 +70,23 @@ reportTransportVarSet <- function(data, baseVarSet, timeResReporting) {
 
   # Report upfront capital cost for vehicle sales
   if (!is.null(data$upfrontCAPEXtrackedFleet)) {
-    data$upfrontCAPEXtrackedFleet <- copy(data$upfrontCAPEXtrackedFleet)
-    data$upfrontCAPEXtrackedFleet <- merge(data$upfrontCAPEXtrackedFleet, data$helpers$decisionTree,
+    upfrontCAPEXtrackedFleet <- data$upfrontCAPEXtrackedFleet
+    upfrontCAPEXtrackedFleet <- upfrontCAPEXtrackedFleet[, .(value = sum(value)), by = c("region", "period", "univocalName", "technology", "unit")]
+    upfrontCAPEXtrackedFleet[, variable := "Purchase Price"]
+    upfrontCAPEXtrackedFleet <- merge(upfrontCAPEXtrackedFleet, data$helpers$decisionTree,
                                          by = intersect(names(data$upfrontCAPEXtrackedFleet),
                                                         names(data$helpers$decisionTree)))
   }
+
   # Split extensive and intensive variables ---------------------------------------------------
   outputVarsExt <- list(FEsplittedCarriers = fleetFEdemandsplittedCarriers,
-                        fleetESdemand = fleetESdemand,
+                        fleetESdemand = baseVarSet$ext$fleetESdemand,
                         fleetEmissions = fleetEmissions,
                         sales = sales,
                         stock = data$fleetSizeAndComposition$fleetVehNumbers,
                         fleetYrlCosts = fleetYrlCosts)
-  outputVarsInt <- list(upfrontCAPEXtrackedFleet = data$upfrontCAPEXtrackedFleet,
-                        fleetEnergyIntensity = fleetEnergyIntensity)
+  outputVarsInt <- list(upfrontCAPEXtrackedFleet = upfrontCAPEXtrackedFleet,
+                        fleetEnergyIntensity = baseVarSet$int$fleetEnergyIntensity)
   outputVars <- list(ext = outputVarsExt,
                      int = outputVarsInt)
 

--- a/R/reportTransportVarSet.R
+++ b/R/reportTransportVarSet.R
@@ -44,7 +44,6 @@ reportTransportVarSet <- function(data, baseVarSet) {
   # Report vehicle sales-----------------------------------------------------------------------------------
   sales <- copy(data$fleetSizeAndComposition$fleetVehNumbersConstrYears[period == constrYear])
   sales[, variable := "Sales"][, constrYear := NULL]
-  sales <- approx_dt(sales, timeResReporting, "period", "value", extrapolate = TRUE)
   sales <- approx_dt(sales, unique(fleetEmissions$period), "period", "value", extrapolate = TRUE)
 
   # Report yearly investment costs-------------------------------------------------------------------------

--- a/R/reportTransportVarSet.R
+++ b/R/reportTransportVarSet.R
@@ -84,8 +84,8 @@ reportTransportVarSet <- function(data, baseVarSet) {
                         sales = sales,
                         stock = data$fleetSizeAndComposition$fleetVehNumbers,
                         fleetYrlCosts = fleetYrlCosts)
-  outputVarsInt <- list(upfrontCAPEXtrackedFleet = upfrontCAPEXtrackedFleet,
-                        fleetEnergyIntensity = baseVarSet$int$fleetEnergyIntensity)
+  outputVarsInt <- list(fleetEnergyIntensity = baseVarSet$int$fleetEnergyIntensity)
+  if (!is.null(data$upfrontCAPEXtrackedFleet)) outputVarsInt <- c(outputVarsInt, list(upfrontCAPEXtrackedFleet = upfrontCAPEXtrackedFleet))
   outputVars <- list(ext = outputVarsExt,
                      int = outputVarsInt)
 

--- a/R/storeData.R
+++ b/R/storeData.R
@@ -45,6 +45,7 @@ storeData <- function(outputFolder, varsList = NULL, ...) {
     if (varName %in% c("histPrefs")) subfolder <- "3_Calibration"
     if (varName %in% c("fleetSizeAndComposition",
                        "vehSalesAndModeShares",
+                       "costsDiscreteChoiceIterations",
                        "fleetVehNumbersIterations",
                        "endogenousCostsIterations",
                        "endogenousCosts",
@@ -120,6 +121,13 @@ storeData <- function(outputFolder, varsList = NULL, ...) {
     for (i in seq_along(vars$endogenousCostsIterations)) {
       saveRDS(vars$endogenousCostsIterations[[i]], file.path(outputFolder, "4_Output",
                                                              paste0("endogenousCostsIteration", i, ".RDS")))
+    }
+    vars <- vars[!names(vars) %in% c("endogenousCostsIterations")]
+  }
+  if (!is.null(vars$costsDiscreteChoiceIterations)) {
+    for (i in seq_along(vars$costsDiscreteChoiceIterations)) {
+      saveRDS(vars$costsDiscreteChoiceIterations[[i]], file.path(outputFolder, "4_Output",
+                                                             paste0("costsDiscreteChoiceIteration", i, ".RDS")))
     }
     vars <- vars[!names(vars) %in% c("endogenousCostsIterations")]
   }

--- a/R/storeData.R
+++ b/R/storeData.R
@@ -28,6 +28,7 @@ storeData <- function(outputFolder, varsList = NULL, ...) {
                        "timeValueCosts",
                        "subsidies",
                        "GDPppp",
+                       "GDPMER",
                        "GDPpcMER",
                        "GDPpcPPP",
                        "population",

--- a/R/storeData.R
+++ b/R/storeData.R
@@ -28,6 +28,8 @@ storeData <- function(outputFolder, varsList = NULL, ...) {
                        "timeValueCosts",
                        "subsidies",
                        "GDPppp",
+                       "GDPpcMER",
+                       "GDPpcPPP",
                        "population",
                        "f29_trpdemand",
                        "helpers")) subfolder <- "1_InputDataRaw"

--- a/R/supportFunctions.R
+++ b/R/supportFunctions.R
@@ -83,3 +83,6 @@ checkForNAsAndDups <- function(dt, varname, codePosition) {
   }
 
 }
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reporting package for edgeTransport
 
-R package **reporttransport**, version **0.5.1**
+R package **reporttransport**, version **0.6.0**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/reporttransport)](https://cran.r-project.org/package=reporttransport)  [![R build status](https://github.com/pik-piam/reporttransport/workflows/check/badge.svg)](https://github.com/pik-piam/reporttransport/actions) [![codecov](https://codecov.io/gh/pik-piam/reporttransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/reporttransport) [![r-universe](https://pik-piam.r-universe.dev/badges/reporttransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -41,7 +41,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **reporttransport** in publications use:
 
-Hoppe J (2024). _reporttransport: Reporting package for edgeTransport_. R package version 0.5.1, <https://github.com/pik-piam/reporttransport>.
+Hoppe J (2024). _reporttransport: Reporting package for edgeTransport_. R package version 0.6.0, <https://github.com/pik-piam/reporttransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -50,7 +50,7 @@ A BibTeX entry for LaTeX users is
   title = {reporttransport: Reporting package for edgeTransport},
   author = {Johanna Hoppe},
   year = {2024},
-  note = {R package version 0.5.1},
+  note = {R package version 0.6.0},
   url = {https://github.com/pik-piam/reporttransport},
 }
 ```

--- a/inst/compareScenarios/cs_06_input_parameters.Rmd
+++ b/inst/compareScenarios/cs_06_input_parameters.Rmd
@@ -1,6 +1,6 @@
 
 # Model input parameters
-```{r}
+```{r, echo=TRUE, message=TRUE}
 library(data.table)
 data <- as.data.table(data)
 
@@ -15,7 +15,7 @@ showTransportInputMultiLinePlots <- function(data, vars, scales = "free_y", nrow
   stopifnot(is.character(mainReg) && length(mainReg) == 1)
 
   d <- data %>%
-    filter(.data$Variable %in% .env$vars) %>%
+    filter(.data$variable %in% .env$vars) %>%
     droplevels()
   dMainScen <- d %>%
     filter(.data$region == .env$mainReg, .data$scenario != "historical") %>%
@@ -45,7 +45,7 @@ showTransportInputMultiLinePlots <- function(data, vars, scales = "free_y", nrow
     geom_line(aes(linetype = .data$scenario)) +
     geom_point(data = dRegiHist, aes(shape = .data$model)) +
     geom_line(data = dRegiHist, aes(group = paste0(.data$model, .data$region)), alpha = 0.5) +
-    facet_wrap(vars(.data$Variable), scales = scales, nrow = nrowNum) +
+    facet_wrap(vars(.data$variable), scales = scales, nrow = nrowNum) +
     theme_minimal() +
     scale_color_manual(values = plotstyle(regions)) +
     expand_limits(y = 0) +
@@ -60,182 +60,191 @@ showTransportInputMultiLinePlots <- function(data, vars, scales = "free_y", nrow
 ## Raw Input data 
 ### Load factor
 #### Pass other
-```{r}
-vars <- as.character(unique(data$Variable))
+```{r, echo=TRUE, message=TRUE}
+library(data.table)
+data <- as.data.table(data)
+
+vars <- as.character(unique(data$variable))
 items <- vars[grepl("Load factor raw\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
+
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Load factor raw|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 #### Pass Four Wheelers
-```{r}
+```{r, echo=TRUE, message=TRUE}
+data <- as.data.table(data)
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 #### Pass Two Wheelers
-```{r}
+```{r, echo=TRUE, message=TRUE}
+data <- as.data.table(data)
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 #### Freight other
-```{r}
+```{r, echo=TRUE, message=TRUE}
+data <- as.data.table(data)
+
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 #### Freight Trucks
-```{r}
+```{r, echo=TRUE, message=TRUE}
+data <- as.data.table(data)
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ### Energy intensity
 #### Pass other
-```{r}
+```{r, echo=TRUE, message=TRUE}
 items <- vars[grepl("Energy intensity sales raw\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Energy intensity raw|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 #### Pass Four Wheelers
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 #### Pass Two Wheelers
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 #### Freight other
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 #### Freight Trucks
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ### Annual mileage
 #### Cars
-```{r}
+```{r, echo=TRUE, message=TRUE}
 items <- vars[grepl(".*Annual mileage.*", vars)]
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 #### Busses
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Bus.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 #### Trucks
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ### Purchase Price Cars, Trucks and Busses
 #### Cars
-```{r}
+```{r, echo=TRUE, message=TRUE}
 items <- vars[grepl(".*Purchase Price.*", vars)]
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 #### Busses
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Bus.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 #### Trucks
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ### Time value costs
 #### Pass other
-```{r}
+```{r, echo=TRUE, message=TRUE}
 items <- vars[grepl("Time value costs\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Time value costs|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 #### Pass Four Wheelers
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 #### Pass Two Wheelers
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
@@ -243,344 +252,344 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ### Annualized TCO for new sales
 #### Capital costs
 ##### Pass other
-```{r}
+```{r, echo=TRUE, message=TRUE}
 items <- vars[grepl("TCO sales Capital costs\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(TCO sales Capital costs|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 ##### Pass Four Wheelers
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ##### Pass Two Wheelers
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 ##### Freight other
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 ##### Freight Trucks
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ####Operating costs (non-fuel)
 ##### Pass other
-```{r}
+```{r, echo=TRUE, message=TRUE}
 items <- vars[grepl("TCO sales Operating costs (total non-fuel)\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(TCO sales Operating costs (total non-fuel)|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 ##### Pass Four Wheelers
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ##### Pass Two Wheelers
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 ##### Freight other
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 ##### Freight Trucks
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 #### Fuel costs
 ##### Pass other
-```{r}
+```{r, echo=TRUE, message=TRUE}
 items <- vars[grepl("TCO sales Fuel costs\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(TCO sales Fuel costs|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 ##### Pass Four Wheelers
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ##### Pass Two Wheelers
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 ##### Freight other
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 ##### Freight Trucks
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ### Scenario specific load factor
 #### Pass other
-```{r}
-vars <- as.character(unique(data$Variable))
+```{r, echo=TRUE, message=TRUE}
+vars <- as.character(unique(data$variable))
 items <- vars[grepl("Load factor\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Load factor|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 #### Pass Four Wheelers
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 #### Pass Two Wheelers
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 #### Freight other
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 #### Freight Trucks
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ### Scenario specific energy intensity
 #### Pass other
-```{r}
+```{r, echo=TRUE, message=TRUE}
 items <- vars[grepl("Energy intensity sales\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Energy intensity|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 #### Pass Four Wheelers
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 #### Pass Two Wheelers
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 #### Freight other
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 #### Freight Trucks
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ### Preference trends
 #### sector-Subsector 1
 ##### Pass
-```{r}
+```{r, echo=TRUE, message=TRUE}
 items <- vars[grepl("Preference\\|S1S\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Preference\\|S1S|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 ##### Freight
-```{r}
+```{r, echo=TRUE, message=TRUE}
 items <- vars[grepl("Preference\\|S1S\\|.*", vars)]
 itemsSplit <- items[grepl(".*Freight.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Preference\\|S1S|\\|Transport|\\|Freight\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 #### Subsector 1 - Subsector 2
-```{r}
+```{r, echo=TRUE, message=TRUE}
 items <- vars[grepl("Preference\\|S2S1\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & grepl(".*Bus.*|.*LDV.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Preference\\|S2S1|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit)/5))
 ``` 
 
 #### Subsector 2 - Subsector 3
-```{r}
+```{r, echo=TRUE, message=TRUE}
 items <- vars[grepl("Preference\\|S3S2\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & grepl(".*LDV.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Preference\\|S3S2|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit)/5))
 ``` 
 
 #### Subsector 3 - Vehicle
 ##### Pass
-```{r}
+```{r, echo=TRUE, message=TRUE}
 items <- vars[grepl("Preference\\|VS3\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items)& grepl(".*LDV.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|LDV\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 ##### Freight
-```{r}
+```{r, echo=TRUE, message=TRUE}
 items <- vars[grepl("Preference\\|VS3\\|.*", vars)]
 itemsSplit <- items[grepl(".*Freight.*", items)& grepl(".*Road.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 #### Vehicle - Fuel
 #### Pass other
-```{r}
+```{r, echo=TRUE, message=TRUE}
 items <- vars[grepl("Preference\\|FV\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*(Walk|Cycle).*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Preference\\|FV|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 ##### Pass Two Wheelers
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 #### Freight other
-```{r}
+```{r, echo=TRUE, message=TRUE}
 items <- vars[grepl("Preference\\|FV\\|.*", vars)]
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Road.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Preference\\|FV|\\|Transport|\\|Freight\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 ##### Freight Trucks
-```{r}
+```{r, echo=TRUE, message=TRUE}
 itemsSplit<- items[grepl("Preference\\|FV\\|.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("Preference\\|FV\\|Transport\\|Freight\\|Road\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$Variable))
+itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ### GDP
-```{r}
+```{r, echo=TRUE, message=TRUE}
 items <- vars[grepl(".*GDP.*", vars)]
 showMultiLinePlots(data, items, nrowNum = 2)
 ```

--- a/inst/compareScenarios/cs_06_input_parameters.Rmd
+++ b/inst/compareScenarios/cs_06_input_parameters.Rmd
@@ -1,249 +1,260 @@
-
 # Model input parameters
-```{r, echo=TRUE, message=TRUE}
-library(data.table)
-data <- as.data.table(data)
+## Raw input data
+```{r}
+library(dplyr)
+library(ggplot2)
 
-showTransportInputMultiLinePlots <- function(data, vars, scales = "free_y", nrowNum = 1,  mainReg = getOption("mip.mainReg")) {
-
-   data <- as.quitte(data)
-
-  # Validate function arguments.
+showTransportInputMultiLinePlots <- function(data, vars, scales = "free_y", nrowNum = 1, mainReg = getOption("mip.mainReg")) {
+  
+  # Validate function arguments
   stopifnot(is.character(vars))
   stopifnot(is.character(scales) && length(scales) == 1)
-  checkGlobalOptionsProvided("mainReg")
   stopifnot(is.character(mainReg) && length(mainReg) == 1)
-
+  
+  # Data preprocessing
   d <- data %>%
-    filter(.data$variable %in% .env$vars) %>%
+    filter(variable %in% vars) %>%
     droplevels()
+  
   dMainScen <- d %>%
-    filter(.data$region == .env$mainReg, .data$scenario != "historical") %>%
+    filter(region == mainReg, scenario != "historical") %>%
     droplevels()
+  
   dMainHist <- d %>%
-    filter(.data$region == .env$mainReg, .data$scenario == "historical") %>%
+    filter(region == mainReg, scenario == "historical") %>%
     droplevels()
+  
   dRegiScen <- d %>%
-    filter(.data$region != .env$mainReg, .data$scenario != "historical") %>%
+    filter(region != mainReg, scenario != "historical") %>%
     droplevels()
+  
   dRegiHist <- d %>%
-    filter(.data$region != .env$mainReg, .data$scenario == "historical") %>%
+    filter(region != mainReg, scenario == "historical") %>%
     droplevels()
+  
   regions <- levels(dRegiScen$region)
-
-  warnMissingVars(dMainScen, vars)
-  if (NROW(dMainScen) == 0) {
+  
+  # Check if there is any data to plot
+  if (nrow(dMainScen) == 0) {
     warning("Nothing to plot.", call. = FALSE)
     return(invisible(NULL))
   }
-
+  
   label <- paste0("(", paste0(levels(d$unit), collapse = ","), ")")
   
-  
   p2 <- dRegiScen %>%
-    ggplot(aes(.data$period, .data$value, color = .data$region)) +
-    geom_line(aes(linetype = .data$scenario)) +
-    geom_point(data = dRegiHist, aes(shape = .data$model)) +
-    geom_line(data = dRegiHist, aes(group = paste0(.data$model, .data$region)), alpha = 0.5) +
-    facet_wrap(vars(.data$variable), scales = scales, nrow = nrowNum) +
+    ggplot(aes(x = period, y = value, color = region)) +
+    geom_line(aes(linetype = scenario)) +
+    geom_point(data = dRegiHist, aes(shape = model)) +
+    geom_line(data = dRegiHist, aes(group = paste0(model, region)), alpha = 0.5) +
+    facet_wrap(~ variable, scales = scales, nrow = nrowNum) +
     theme_minimal() +
     scale_color_manual(values = plotstyle(regions)) +
     expand_limits(y = 0) +
     ylab(label)
-
-  # Show plots.
+  
   print(p2)
   cat("\n\n")
 }
 ```
 
-## Raw Input data 
 ### Load factor
 #### Pass other
-```{r, echo=TRUE, message=TRUE}
-library(data.table)
-data <- as.data.table(data)
-
+```{r}
 vars <- as.character(unique(data$variable))
 items <- vars[grepl("Load factor raw\\|.*", vars)]
-itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
-
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(Load factor raw|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
-showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
-```  
+itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*|.*Two Wheelers.*|.*Non-motorized.*", items)]
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("(Load factor raw|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable))
+itemsSplit <- unique(plotData$variable)
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit) / 5))
+```
 
 #### Pass Four Wheelers
-```{r, echo=TRUE, message=TRUE}
-data <- as.data.table(data)
+```{r}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
-showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
-```  
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable))
+itemsSplit <- unique(plotData$variable)
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit) / 6))
+```
 
 #### Pass Two Wheelers
-```{r, echo=TRUE, message=TRUE}
-data <- as.data.table(data)
+```{r}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("^.*\\|Two Wheelers\\|", "", variable))
+itemsSplit <- unique(plotData$variable)
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
-```  
+```
 
 #### Freight other
-```{r, echo=TRUE, message=TRUE}
-data <- as.data.table(data)
-
+```{r}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable))
+itemsSplit <- unique(plotData$variable)
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
-```  
+```
 
 #### Freight Trucks
-```{r, echo=TRUE, message=TRUE}
-data <- as.data.table(data)
-itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
-showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
-```  
+```{r}
+itemsSplit <- items[grepl(".*Freight.*", .) & grepl(".*Truck.*", .)]
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable))
+itemsSplit <- unique(plotData$variable)
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit) / 6))
+```
 
 ### Energy intensity
 #### Pass other
-```{r, echo=TRUE, message=TRUE}
+```{r}
 items <- vars[grepl("Energy intensity sales raw\\|.*", vars)]
-itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(Energy intensity raw|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
-showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
-```  
+itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*|.*Two Wheelers.*|.*Non-motorized.*", items)]
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("(Energy intensity raw|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable))
+itemsSplit <- unique(plotData$variable)
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit) / 5))
+```
 
 #### Pass Four Wheelers
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
-showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
-```  
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable))
+itemsSplit <- unique(plotData$variable)
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit) / 6))
+```
 
 #### Pass Two Wheelers
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("^.*\\|Two Wheelers\\|", "", variable))
+itemsSplit <- unique(plotData$variable)
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
-```  
+```
 
 #### Freight other
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable))
+itemsSplit <- unique(plotData$variable)
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
-```  
+```
 
 #### Freight Trucks
-```{r, echo=TRUE, message=TRUE}
-itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
-showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
-```  
+```{r}
+itemsSplit <- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable))
+itemsSplit <- unique(plotData$variable)
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit) / 6))
+```
 
 ### Annual mileage
 #### Cars
-```{r, echo=TRUE, message=TRUE}
+```{r}
 items <- vars[grepl(".*Annual mileage.*", vars)]
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
-showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
-```  
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable))
+itemsSplit <- unique(plotData$variable)
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit) / 6))
+```
 
 #### Busses
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Bus.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Road\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
-showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
-```  
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("^.*\\|Road\\|", "", variable))
+itemsSplit <- unique(plotData$variable)
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit) / 6))
+```
+
 #### Trucks
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ### Purchase Price Cars, Trucks and Busses
 #### Cars
-```{r, echo=TRUE, message=TRUE}
+```{r}
 items <- vars[grepl(".*Purchase Price.*", vars)]
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 #### Busses
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Bus.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Road\\|", "", variable)]
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("^.*\\|Road\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 #### Trucks
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ### Time value costs
 #### Pass other
-```{r, echo=TRUE, message=TRUE}
+```{r}
 items <- vars[grepl("Time value costs\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(Time value costs|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("(Time value costs|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 #### Pass Four Wheelers
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 #### Pass Two Wheelers
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("^.*\\|Two Wheelers\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
@@ -252,236 +263,227 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ### Annualized TCO for new sales
 #### Capital costs
 ##### Pass other
-```{r, echo=TRUE, message=TRUE}
+```{r}
 items <- vars[grepl("TCO sales Capital costs\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(TCO sales Capital costs|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("(TCO sales Capital costs|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 ##### Pass Four Wheelers
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ##### Pass Two Wheelers
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("^.*\\|Two Wheelers\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 ##### Freight other
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 ##### Freight Trucks
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
-####Operating costs (non-fuel)
+#### Operating costs (non-fuel)
 ##### Pass other
-```{r, echo=TRUE, message=TRUE}
-items <- vars[grepl("TCO sales Operating costs (total non-fuel)\\|.*", vars)]
+```{r}
+items <- vars[grepl("TCO sales Operating costs \\(total non-fuel\\)\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(TCO sales Operating costs (total non-fuel)|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("(TCO sales Operating costs \\(total non-fuel\\)|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 ##### Pass Four Wheelers
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ##### Pass Two Wheelers
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
+plotData <- data %>%
+  filter(variable %in% itemsSplit) %>%
+  mutate(variable = gsub("^.*\\|Two Wheelers\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 ##### Freight other
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 ##### Freight Trucks
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 #### Fuel costs
 ##### Pass other
-```{r, echo=TRUE, message=TRUE}
+```{r}
 items <- vars[grepl("TCO sales Fuel costs\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(TCO sales Fuel costs|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("(TCO sales Fuel costs|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 ##### Pass Four Wheelers
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ##### Pass Two Wheelers
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("^.*\\|Two Wheelers\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 ##### Freight other
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 ##### Freight Trucks
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ### Scenario specific load factor
 #### Pass other
-```{r, echo=TRUE, message=TRUE}
+```{r}
 vars <- as.character(unique(data$variable))
 items <- vars[grepl("Load factor\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(Load factor|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("(Load factor|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 #### Pass Four Wheelers
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 #### Pass Two Wheelers
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("^.*\\|Two Wheelers\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 #### Freight other
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 #### Freight Trucks
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ### Scenario specific energy intensity
 #### Pass other
-```{r, echo=TRUE, message=TRUE}
+```{r}
 items <- vars[grepl("Energy intensity sales\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(Energy intensity|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("(Energy intensity|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 #### Pass Four Wheelers
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 #### Pass Two Wheelers
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("^.*\\|Two Wheelers\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 #### Freight other
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 #### Freight Trucks
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
@@ -489,107 +491,97 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 ### Preference trends
 #### sector-Subsector 1
 ##### Pass
-```{r, echo=TRUE, message=TRUE}
+```{r}
 items <- vars[grepl("Preference\\|S1S\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(Preference\\|S1S|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("(Preference\\|S1S|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 ##### Freight
-```{r, echo=TRUE, message=TRUE}
+```{r}
 items <- vars[grepl("Preference\\|S1S\\|.*", vars)]
 itemsSplit <- items[grepl(".*Freight.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(Preference\\|S1S|\\|Transport|\\|Freight\\||\\|Bunkers)", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("(Preference\\|S1S|\\|Transport|\\|Freight\\||\\|Bunkers)", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 #### Subsector 1 - Subsector 2
-```{r, echo=TRUE, message=TRUE}
+```{r}
 items <- vars[grepl("Preference\\|S2S1\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & grepl(".*Bus.*|.*LDV.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(Preference\\|S2S1|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("(Preference\\|S2S1|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit)/5))
 ``` 
 
 #### Subsector 2 - Subsector 3
-```{r, echo=TRUE, message=TRUE}
+```{r}
 items <- vars[grepl("Preference\\|S3S2\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & grepl(".*LDV.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(Preference\\|S3S2|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("(Preference\\|S3S2|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit)/5))
 ``` 
 
 #### Subsector 3 - Vehicle
 ##### Pass
-```{r, echo=TRUE, message=TRUE}
+```{r}
 items <- vars[grepl("Preference\\|VS3\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items)& grepl(".*LDV.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|LDV\\|", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("^.*\\|LDV\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 ##### Freight
-```{r, echo=TRUE, message=TRUE}
+```{r}
 items <- vars[grepl("Preference\\|VS3\\|.*", vars)]
 itemsSplit <- items[grepl(".*Freight.*", items)& grepl(".*Road.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Road\\|", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("^.*\\|Road\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 #### Vehicle - Fuel
 #### Pass other
-```{r, echo=TRUE, message=TRUE}
+```{r}
 items <- vars[grepl("Preference\\|FV\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*(Walk|Cycle).*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(Preference\\|FV|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("(Preference\\|FV|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 ##### Pass Two Wheelers
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("^.*\\|Two Wheelers\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
 #### Freight other
-```{r, echo=TRUE, message=TRUE}
+```{r}
 items <- vars[grepl("Preference\\|FV\\|.*", vars)]
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Road.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("(Preference\\|FV|\\|Transport|\\|Freight\\||\\|Bunkers)", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("(Preference\\|FV|\\|Transport|\\|Freight\\||\\|Bunkers)", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
 ##### Freight Trucks
-```{r, echo=TRUE, message=TRUE}
+```{r}
 itemsSplit<- items[grepl("Preference\\|FV\\|.*", items) & grepl(".*Truck.*", items)]
-plotData <- data[variable %in% itemsSplit]
-plotData[, variable := gsub("Preference\\|FV\\|Transport\\|Freight\\|Road\\|", "", variable)]
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("Preference\\|FV\\|Transport\\|Freight\\|Road\\|", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ### GDP
-```{r, echo=TRUE, message=TRUE}
+```{r}
 items <- vars[grepl(".*GDP.*", vars)]
 showMultiLinePlots(data, items, nrowNum = 2)
 ```

--- a/inst/compareScenarios/cs_06_input_parameters.Rmd
+++ b/inst/compareScenarios/cs_06_input_parameters.Rmd
@@ -3,7 +3,7 @@
 ```{r}
 library(data.table)
 data <- as.data.table(data)
-typeOf(data)
+
 showTransportInputMultiLinePlots <- function(data, vars, scales = "free_y", nrowNum = 1,  mainReg = getOption("mip.mainReg")) {
 
    data <- as.quitte(data)
@@ -15,7 +15,7 @@ showTransportInputMultiLinePlots <- function(data, vars, scales = "free_y", nrow
   stopifnot(is.character(mainReg) && length(mainReg) == 1)
 
   d <- data %>%
-    filter(.data$variable %in% .env$vars) %>%
+    filter(.data$Variable %in% .env$vars) %>%
     droplevels()
   dMainScen <- d %>%
     filter(.data$region == .env$mainReg, .data$scenario != "historical") %>%
@@ -45,7 +45,7 @@ showTransportInputMultiLinePlots <- function(data, vars, scales = "free_y", nrow
     geom_line(aes(linetype = .data$scenario)) +
     geom_point(data = dRegiHist, aes(shape = .data$model)) +
     geom_line(data = dRegiHist, aes(group = paste0(.data$model, .data$region)), alpha = 0.5) +
-    facet_wrap(vars(.data$variable), scales = scales, nrow = nrowNum) +
+    facet_wrap(vars(.data$Variable), scales = scales, nrow = nrowNum) +
     theme_minimal() +
     scale_color_manual(values = plotstyle(regions)) +
     expand_limits(y = 0) +
@@ -61,12 +61,12 @@ showTransportInputMultiLinePlots <- function(data, vars, scales = "free_y", nrow
 ### Load factor
 #### Pass other
 ```{r}
-vars <- as.character(unique(data$variable))
+vars <- as.character(unique(data$Variable))
 items <- vars[grepl("Load factor raw\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Load factor raw|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
@@ -75,7 +75,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
@@ -84,7 +84,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
@@ -93,7 +93,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
@@ -102,7 +102,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
@@ -113,7 +113,7 @@ items <- vars[grepl("Energy intensity sales raw\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Energy intensity raw|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
@@ -122,7 +122,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
@@ -131,7 +131,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
@@ -140,7 +140,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
@@ -149,7 +149,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
@@ -160,7 +160,7 @@ items <- vars[grepl(".*Annual mileage.*", vars)]
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
@@ -169,7 +169,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Bus.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 #### Trucks
@@ -177,7 +177,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
@@ -188,7 +188,7 @@ items <- vars[grepl(".*Purchase Price.*", vars)]
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
@@ -197,7 +197,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Bus.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
@@ -206,7 +206,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
@@ -217,7 +217,7 @@ items <- vars[grepl("Time value costs\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Time value costs|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
@@ -226,7 +226,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
@@ -235,7 +235,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
@@ -248,7 +248,7 @@ items <- vars[grepl("TCO sales Capital costs\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(TCO sales Capital costs|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
@@ -257,7 +257,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
@@ -266,7 +266,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
@@ -275,7 +275,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
@@ -284,7 +284,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
@@ -295,7 +295,7 @@ items <- vars[grepl("TCO sales Operating costs (total non-fuel)\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(TCO sales Operating costs (total non-fuel)|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
@@ -304,7 +304,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
@@ -313,7 +313,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
@@ -322,7 +322,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
@@ -331,7 +331,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
@@ -342,7 +342,7 @@ items <- vars[grepl("TCO sales Fuel costs\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(TCO sales Fuel costs|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
@@ -351,7 +351,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
@@ -360,7 +360,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
@@ -369,7 +369,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
@@ -378,19 +378,19 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
 ### Scenario specific load factor
 #### Pass other
 ```{r}
-vars <- as.character(unique(data$variable))
+vars <- as.character(unique(data$Variable))
 items <- vars[grepl("Load factor\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Load factor|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
@@ -399,7 +399,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
@@ -408,7 +408,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
@@ -417,7 +417,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
@@ -426,7 +426,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
@@ -437,7 +437,7 @@ items <- vars[grepl("Energy intensity sales\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Energy intensity|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
@@ -446,7 +446,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
@@ -455,7 +455,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
@@ -464,7 +464,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
@@ -473,7 +473,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 
@@ -485,7 +485,7 @@ items <- vars[grepl("Preference\\|S1S\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Preference\\|S1S|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
@@ -495,7 +495,7 @@ items <- vars[grepl("Preference\\|S1S\\|.*", vars)]
 itemsSplit <- items[grepl(".*Freight.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Preference\\|S1S|\\|Transport|\\|Freight\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
@@ -505,7 +505,7 @@ items <- vars[grepl("Preference\\|S2S1\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & grepl(".*Bus.*|.*LDV.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Preference\\|S2S1|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit)/5))
 ``` 
 
@@ -515,7 +515,7 @@ items <- vars[grepl("Preference\\|S3S2\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & grepl(".*LDV.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Preference\\|S3S2|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit)/5))
 ``` 
 
@@ -526,7 +526,7 @@ items <- vars[grepl("Preference\\|VS3\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items)& grepl(".*LDV.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|LDV\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
@@ -536,7 +536,7 @@ items <- vars[grepl("Preference\\|VS3\\|.*", vars)]
 itemsSplit <- items[grepl(".*Freight.*", items)& grepl(".*Road.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Road\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
@@ -547,7 +547,7 @@ items <- vars[grepl("Preference\\|FV\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*(Walk|Cycle).*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Preference\\|FV|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
@@ -556,7 +556,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
 
@@ -566,7 +566,7 @@ items <- vars[grepl("Preference\\|FV\\|.*", vars)]
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Road.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("(Preference\\|FV|\\|Transport|\\|Freight\\||\\|Bunkers)", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
 
@@ -575,7 +575,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 itemsSplit<- items[grepl("Preference\\|FV\\|.*", items) & grepl(".*Truck.*", items)]
 plotData <- data[variable %in% itemsSplit]
 plotData[, variable := gsub("Preference\\|FV\\|Transport\\|Freight\\|Road\\|", "", variable)]
-itemsSplit <- as.character(unique(plotData$variable))
+itemsSplit <- as.character(unique(plotData$Variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
 

--- a/inst/compareScenarios/cs_06_input_parameters.Rmd
+++ b/inst/compareScenarios/cs_06_input_parameters.Rmd
@@ -1,0 +1,542 @@
+# Model input parameters
+```{r}
+library(data.table)
+data <- as.data.table(data)
+showTransportInputMultiLinePlots <- function(data, vars, scales = "free_y", nrowNum = 1,  mainReg = getOption("mip.mainReg")) {
+
+   data <- as.quitte(data)
+
+  # Validate function arguments.
+  stopifnot(is.character(vars))
+  stopifnot(is.character(scales) && length(scales) == 1)
+  checkGlobalOptionsProvided("mainReg")
+  stopifnot(is.character(mainReg) && length(mainReg) == 1)
+
+  d <- data %>%
+    filter(.data$variable %in% .env$vars) %>%
+    droplevels()
+  dMainScen <- d %>%
+    filter(.data$region == .env$mainReg, .data$scenario != "historical") %>%
+    droplevels()
+  dMainHist <- d %>%
+    filter(.data$region == .env$mainReg, .data$scenario == "historical") %>%
+    droplevels()
+  dRegiScen <- d %>%
+    filter(.data$region != .env$mainReg, .data$scenario != "historical") %>%
+    droplevels()
+  dRegiHist <- d %>%
+    filter(.data$region != .env$mainReg, .data$scenario == "historical") %>%
+    droplevels()
+  regions <- levels(dRegiScen$region)
+
+  warnMissingVars(dMainScen, vars)
+  if (NROW(dMainScen) == 0) {
+    warning("Nothing to plot.", call. = FALSE)
+    return(invisible(NULL))
+  }
+
+  label <- paste0("(", paste0(levels(d$unit), collapse = ","), ")")
+  
+  
+  p2 <- dRegiScen %>%
+    ggplot(aes(.data$period, .data$value, color = .data$region)) +
+    geom_line(aes(linetype = .data$scenario)) +
+    geom_point(data = dRegiHist, aes(shape = .data$model)) +
+    geom_line(data = dRegiHist, aes(group = paste0(.data$model, .data$region)), alpha = 0.5) +
+    facet_wrap(vars(.data$variable), scales = scales, nrow = nrowNum) +
+    theme_minimal() +
+    scale_color_manual(values = plotstyle(regions)) +
+    expand_limits(y = 0) +
+    ylab(label)
+
+  # Show plots.
+  print(p2)
+  cat("\n\n")
+}
+```
+## Raw Input data 
+### Load factor
+#### Pass other
+```{r}
+vars <- as.character(unique(data$variable))
+items <- vars[grepl("Load factor raw\\|.*", vars)]
+itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(Load factor raw|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
+```  
+#### Pass Four Wheelers
+```{r}
+itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+#### Pass Two Wheelers
+```{r}
+itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
+```  
+#### Freight other
+```{r}
+itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
+```  
+#### Freight Trucks
+```{r}
+itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+
+### Energy intensity
+#### Pass other
+```{r}
+items <- vars[grepl("Energy intensity sales raw\\|.*", vars)]
+itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(Energy intensity raw|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
+```  
+#### Pass Four Wheelers
+```{r}
+itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+#### Pass Two Wheelers
+```{r}
+itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
+```  
+#### Freight other
+```{r}
+itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
+```  
+#### Freight Trucks
+```{r}
+itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+
+### Annual mileage
+#### Cars
+```{r}
+items <- vars[grepl(".*Annual mileage.*", vars)]
+itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+#### Busses
+```{r}
+itemsSplit <- items[grepl(".*Bus.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Road\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+#### Trucks
+```{r}
+itemsSplit <- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+
+### Purchase Price Cars, Trucks and Busses
+#### Cars
+```{r}
+items <- vars[grepl(".*Purchase Price.*", vars)]
+itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+#### Busses
+```{r}
+itemsSplit <- items[grepl(".*Bus.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Road\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+#### Trucks
+```{r}
+itemsSplit <- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+
+### Time value costs
+#### Pass other
+```{r}
+items <- vars[grepl("Time value costs\\|.*", vars)]
+itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(Time value costs|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
+```  
+#### Pass Four Wheelers
+```{r}
+itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+#### Pass Two Wheelers
+```{r}
+itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
+```  
+
+## Scenario specific input data
+### Annualized TCO for new sales
+#### Capital costs
+##### Pass other
+```{r}
+items <- vars[grepl("TCO sales Capital costs\\|.*", vars)]
+itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(TCO sales Capital costs|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
+```  
+##### Pass Four Wheelers
+```{r}
+itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+##### Pass Two Wheelers
+```{r}
+itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
+```  
+##### Freight other
+```{r}
+itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
+```  
+##### Freight Trucks
+```{r}
+itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+
+####Operating costs (non-fuel)
+##### Pass other
+```{r}
+items <- vars[grepl("TCO sales Operating costs (total non-fuel)\\|.*", vars)]
+itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(TCO sales Operating costs (total non-fuel)|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
+```  
+##### Pass Four Wheelers
+```{r}
+itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+##### Pass Two Wheelers
+```{r}
+itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
+```  
+##### Freight other
+```{r}
+itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
+```  
+##### Freight Trucks
+```{r}
+itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+
+#### Fuel costs
+##### Pass other
+```{r}
+items <- vars[grepl("TCO sales Fuel costs\\|.*", vars)]
+itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(TCO sales Fuel costs|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
+```  
+##### Pass Four Wheelers
+```{r}
+itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+##### Pass Two Wheelers
+```{r}
+itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
+```  
+##### Freight other
+```{r}
+itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
+```  
+##### Freight Trucks
+```{r}
+itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+
+### Scenario specific load factor
+#### Pass other
+```{r}
+vars <- as.character(unique(data$variable))
+items <- vars[grepl("Load factor\\|.*", vars)]
+itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(Load factor|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
+```  
+#### Pass Four Wheelers
+```{r}
+itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+#### Pass Two Wheelers
+```{r}
+itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
+```  
+#### Freight other
+```{r}
+itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
+```  
+#### Freight Trucks
+```{r}
+itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+
+### Scenario specific energy intensity
+#### Pass other
+```{r}
+items <- vars[grepl("Energy intensity sales\\|.*", vars)]
+itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(Energy intensity|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
+```  
+#### Pass Four Wheelers
+```{r}
+itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+#### Pass Two Wheelers
+```{r}
+itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
+```  
+#### Freight other
+```{r}
+itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
+```  
+#### Freight Trucks
+```{r}
+itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Road\\|[A-Za-z]+\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+
+### Preference trends
+#### sector-Subsector 1
+##### Pass
+```{r}
+items <- vars[grepl("Preference\\|S1S\\|.*", vars)]
+itemsSplit <- items[grepl(".*Pass.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(Preference\\|S1S|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
+```  
+##### Freight
+```{r}
+items <- vars[grepl("Preference\\|S1S\\|.*", vars)]
+itemsSplit <- items[grepl(".*Freight.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(Preference\\|S1S|\\|Transport|\\|Freight\\||\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
+```  
+#### Subsector 1 - Subsector 2
+```{r}
+items <- vars[grepl("Preference\\|S2S1\\|.*", vars)]
+itemsSplit <- items[grepl(".*Pass.*", items) & grepl(".*Bus.*|.*LDV.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(Preference\\|S2S1|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit)/5))
+``` 
+#### Subsector 2 - Subsector 3
+```{r}
+items <- vars[grepl("Preference\\|S3S2\\|.*", vars)]
+itemsSplit <- items[grepl(".*Pass.*", items) & grepl(".*LDV.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(Preference\\|S3S2|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit)/5))
+``` 
+
+#### Subsector 3 - Vehicle
+##### Pass
+```{r}
+items <- vars[grepl("Preference\\|VS3\\|.*", vars)]
+itemsSplit <- items[grepl(".*Pass.*", items)& grepl(".*LDV.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|LDV\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
+```  
+##### Freight
+```{r}
+items <- vars[grepl("Preference\\|VS3\\|.*", vars)]
+itemsSplit <- items[grepl(".*Freight.*", items)& grepl(".*Road.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Road\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
+```  
+#### Vehicle - Fuel
+#### Pass other
+```{r}
+items <- vars[grepl("Preference\\|FV\\|.*", vars)]
+itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*(Walk|Cycle).*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(Preference\\|FV|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
+```  
+##### Pass Two Wheelers
+```{r}
+itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
+```  
+#### Freight other
+```{r}
+items <- vars[grepl("Preference\\|FV\\|.*", vars)]
+itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Road.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("(Preference\\|FV|\\|Transport|\\|Freight\\||\\|Bunkers)", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
+```  
+##### Freight Trucks
+```{r}
+itemsSplit<- items[grepl("Preference\\|FV\\|.*", items) & grepl(".*Truck.*", items)]
+plotData <- data[variable %in% itemsSplit]
+plotData[, variable := gsub("Preference\\|FV\\|Transport\\|Freight\\|Road\\|", "", variable)]
+itemsSplit <- as.character(unique(plotData$variable))
+showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
+```  
+
+### GDP
+```{r}
+items <- vars[grepl(".*GDP.*", vars)]
+showMultiLinePlots(data, items, nrowNum = 2)
+```

--- a/inst/compareScenarios/cs_06_input_parameters.Rmd
+++ b/inst/compareScenarios/cs_06_input_parameters.Rmd
@@ -3,6 +3,7 @@
 ```{r}
 library(data.table)
 data <- as.data.table(data)
+typeOf(data)
 showTransportInputMultiLinePlots <- function(data, vars, scales = "free_y", nrowNum = 1,  mainReg = getOption("mip.mainReg")) {
 
    data <- as.quitte(data)

--- a/inst/compareScenarios/cs_06_input_parameters.Rmd
+++ b/inst/compareScenarios/cs_06_input_parameters.Rmd
@@ -62,7 +62,7 @@ showTransportInputMultiLinePlots <- function(data, vars, scales = "free_y", nrow
 #### Pass other
 ```{r}
 vars <- as.character(unique(data$variable))
-items <- vars[grepl("Load factor raw\\|.*", vars)]
+items <- vars[grepl("Load factor (raw)\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*|.*Two Wheelers.*|.*Non-motorized.*", items)]
 plotData <- data %>%
   filter(variable %in% itemsSplit) %>%
@@ -114,11 +114,11 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 ### Energy intensity
 #### Pass other
 ```{r}
-items <- vars[grepl("Energy intensity sales raw\\|.*", vars)]
+items <- vars[grepl("Energy intensity (raw)\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*|.*Two Wheelers.*|.*Non-motorized.*", items)]
 plotData <- data %>%
   filter(variable %in% itemsSplit) %>%
-  mutate(variable = gsub("(Energy intensity raw|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable))
+  mutate(variable = gsub("(Energy intensity (raw)|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable))
 itemsSplit <- unique(plotData$variable)
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit) / 5))
 ```
@@ -451,7 +451,7 @@ showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(
 ```{r}
 items <- vars[grepl("Energy intensity sales\\|.*", vars)]
 itemsSplit <- items[grepl(".*Pass.*", items) & !grepl(".*Four Wheelers.*", items) & !grepl(".*Two Wheelers.*", items)& !grepl(".*Non-motorized.*", items)]
-plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("(Energy intensity|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable))
+plotData <- data %>%   filter(variable %in% itemsSplit) %>%   mutate(variable = gsub("(Energy intensity sales|\\|Transport|\\|Pass\\||\\|Bunkers)", "", variable))
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  

--- a/inst/compareScenarios/cs_06_input_parameters.Rmd
+++ b/inst/compareScenarios/cs_06_input_parameters.Rmd
@@ -1,3 +1,4 @@
+
 # Model input parameters
 ```{r}
 library(data.table)
@@ -54,6 +55,7 @@ showTransportInputMultiLinePlots <- function(data, vars, scales = "free_y", nrow
   cat("\n\n")
 }
 ```
+
 ## Raw Input data 
 ### Load factor
 #### Pass other
@@ -66,6 +68,7 @@ plotData[, variable := gsub("(Load factor raw|\\|Transport|\\|Pass\\||\\|Bunkers
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
+
 #### Pass Four Wheelers
 ```{r}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
@@ -74,6 +77,7 @@ plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
+
 #### Pass Two Wheelers
 ```{r}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
@@ -82,6 +86,7 @@ plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
+
 #### Freight other
 ```{r}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
@@ -90,6 +95,7 @@ plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
+
 #### Freight Trucks
 ```{r}
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
@@ -109,6 +115,7 @@ plotData[, variable := gsub("(Energy intensity raw|\\|Transport|\\|Pass\\||\\|Bu
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
+
 #### Pass Four Wheelers
 ```{r}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
@@ -117,6 +124,7 @@ plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
+
 #### Pass Two Wheelers
 ```{r}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
@@ -125,6 +133,7 @@ plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
+
 #### Freight other
 ```{r}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
@@ -133,6 +142,7 @@ plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
+
 #### Freight Trucks
 ```{r}
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
@@ -152,6 +162,7 @@ plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
+
 #### Busses
 ```{r}
 itemsSplit <- items[grepl(".*Bus.*", items)]
@@ -179,6 +190,7 @@ plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
+
 #### Busses
 ```{r}
 itemsSplit <- items[grepl(".*Bus.*", items)]
@@ -187,6 +199,7 @@ plotData[, variable := gsub("^.*\\|Road\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
+
 #### Trucks
 ```{r}
 itemsSplit <- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
@@ -206,6 +219,7 @@ plotData[, variable := gsub("(Time value costs|\\|Transport|\\|Pass\\||\\|Bunker
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
+
 #### Pass Four Wheelers
 ```{r}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
@@ -214,6 +228,7 @@ plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
+
 #### Pass Two Wheelers
 ```{r}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
@@ -235,6 +250,7 @@ plotData[, variable := gsub("(TCO sales Capital costs|\\|Transport|\\|Pass\\||\\
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
+
 ##### Pass Four Wheelers
 ```{r}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
@@ -243,6 +259,7 @@ plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
+
 ##### Pass Two Wheelers
 ```{r}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
@@ -251,6 +268,7 @@ plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
+
 ##### Freight other
 ```{r}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
@@ -259,6 +277,7 @@ plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
+
 ##### Freight Trucks
 ```{r}
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
@@ -278,6 +297,7 @@ plotData[, variable := gsub("(TCO sales Operating costs (total non-fuel)|\\|Tran
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
+
 ##### Pass Four Wheelers
 ```{r}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
@@ -286,6 +306,7 @@ plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
+
 ##### Pass Two Wheelers
 ```{r}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
@@ -294,6 +315,7 @@ plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
+
 ##### Freight other
 ```{r}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
@@ -302,6 +324,7 @@ plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
+
 ##### Freight Trucks
 ```{r}
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
@@ -321,6 +344,7 @@ plotData[, variable := gsub("(TCO sales Fuel costs|\\|Transport|\\|Pass\\||\\|Bu
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
+
 ##### Pass Four Wheelers
 ```{r}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
@@ -329,6 +353,7 @@ plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
+
 ##### Pass Two Wheelers
 ```{r}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
@@ -337,6 +362,7 @@ plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
+
 ##### Freight other
 ```{r}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
@@ -345,6 +371,7 @@ plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
+
 ##### Freight Trucks
 ```{r}
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
@@ -365,6 +392,7 @@ plotData[, variable := gsub("(Load factor|\\|Transport|\\|Pass\\||\\|Bunkers)", 
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
+
 #### Pass Four Wheelers
 ```{r}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
@@ -373,6 +401,7 @@ plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
+
 #### Pass Two Wheelers
 ```{r}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
@@ -381,6 +410,7 @@ plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
+
 #### Freight other
 ```{r}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
@@ -389,6 +419,7 @@ plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
+
 #### Freight Trucks
 ```{r}
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
@@ -408,6 +439,7 @@ plotData[, variable := gsub("(Energy intensity|\\|Transport|\\|Pass\\||\\|Bunker
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
+
 #### Pass Four Wheelers
 ```{r}
 itemsSplit <- items[grepl(".*Four Wheelers.*", items)]
@@ -416,6 +448,7 @@ plotData[, variable := gsub("^.*\\|Four Wheelers\\|[A-Za-z]+\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/6))
 ```  
+
 #### Pass Two Wheelers
 ```{r}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
@@ -424,6 +457,7 @@ plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
+
 #### Freight other
 ```{r}
 itemsSplit <- items[grepl(".*Freight.*", items) & !grepl(".*Truck.*", items)]
@@ -432,6 +466,7 @@ plotData[, variable := gsub("(\\|Transport|\\|Pass|\\|Bunkers)", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
+
 #### Freight Trucks
 ```{r}
 itemsSplit<- items[grepl(".*Freight.*", items) & grepl(".*Truck.*", items)]
@@ -452,6 +487,7 @@ plotData[, variable := gsub("(Preference\\|S1S|\\|Transport|\\|Pass\\||\\|Bunker
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
+
 ##### Freight
 ```{r}
 items <- vars[grepl("Preference\\|S1S\\|.*", vars)]
@@ -461,6 +497,7 @@ plotData[, variable := gsub("(Preference\\|S1S|\\|Transport|\\|Freight\\||\\|Bun
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
+
 #### Subsector 1 - Subsector 2
 ```{r}
 items <- vars[grepl("Preference\\|S2S1\\|.*", vars)]
@@ -470,6 +507,7 @@ plotData[, variable := gsub("(Preference\\|S2S1|\\|Transport|\\|Pass\\||\\|Bunke
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit)/5))
 ``` 
+
 #### Subsector 2 - Subsector 3
 ```{r}
 items <- vars[grepl("Preference\\|S3S2\\|.*", vars)]
@@ -490,6 +528,7 @@ plotData[, variable := gsub("^.*\\|LDV\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
+
 ##### Freight
 ```{r}
 items <- vars[grepl("Preference\\|VS3\\|.*", vars)]
@@ -499,6 +538,7 @@ plotData[, variable := gsub("^.*\\|Road\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
+
 #### Vehicle - Fuel
 #### Pass other
 ```{r}
@@ -509,6 +549,7 @@ plotData[, variable := gsub("(Preference\\|FV|\\|Transport|\\|Pass\\||\\|Bunkers
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
+
 ##### Pass Two Wheelers
 ```{r}
 itemsSplit <- items[grepl(".*Two Wheelers.*", items)]
@@ -517,6 +558,7 @@ plotData[, variable := gsub("^.*\\|Two Wheelers\\|", "", variable)]
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = 2)
 ```  
+
 #### Freight other
 ```{r}
 items <- vars[grepl("Preference\\|FV\\|.*", vars)]
@@ -526,6 +568,7 @@ plotData[, variable := gsub("(Preference\\|FV|\\|Transport|\\|Freight\\||\\|Bunk
 itemsSplit <- as.character(unique(plotData$variable))
 showTransportInputMultiLinePlots(plotData, itemsSplit, nrowNum = ceiling(length(itemsSplit )/5))
 ```  
+
 ##### Freight Trucks
 ```{r}
 itemsSplit<- items[grepl("Preference\\|FV\\|.*", items) & grepl(".*Truck.*", items)]

--- a/inst/compareScenarios/cs_08_transportRemindInputfiles.Rmd
+++ b/inst/compareScenarios/cs_08_transportRemindInputfiles.Rmd
@@ -170,7 +170,7 @@ for (teEs in unique_teEs) {
     geom_line() +
     facet_wrap(~ all_regi, scales = axisScaling) +  # Facet by region/country
     labs(
-      title = paste("Capital cost for:", teEs),
+      title = paste("Final energy for:", teEs),
       x = "Time",
       y = "Value",
       color = "EDGE Scenario"

--- a/inst/compareScenarios/cs_08_transportRemindInputfiles.Rmd
+++ b/inst/compareScenarios/cs_08_transportRemindInputfiles.Rmd
@@ -1,0 +1,198 @@
+---
+title: "Untitled"
+author: "Johanna Hoppe"
+date: "2024-09-05"
+output: html_document
+---
+
+```{r setup, echo=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+
+```
+
+
+```{r preprocessing, echo=FALSE, message=FALSE, results='hide'}
+library(ggplot2)
+library(data.table)
+timeResReporting <-  c(seq(2005, 2060, by = 5), seq(2070, 2100, by = 10))
+axisScaling = "free_y" #fixed
+paths = params$mifScen
+paths <- gsub("Transport.mif", "5_REMINDinputData", paths)
+
+files <- list(f29_trpdemand = "f29_trpdemand",
+              f35_demByTech = "f35_demByTech",
+              f35_esCapCost = "f35_esCapCost", 
+              f35_fe2es = "f35_fe2es")
+
+# Load files from all paths
+loaded_files <- lapply(files, function(file_name) {
+  lapply(paths, function(path) {
+    # Load the data using fread
+    if (file.exists(file.path(path, paste0(file_name, ".csv")))) fread(file.path(path, paste0(file_name, ".csv")))
+  })
+})
+
+# Clean the loaded data by applying the required transformations
+loaded_files <- lapply(loaded_files, function(file_list) {
+  lapply(file_list, function(dt) {
+    # If the column V1 exists, remove it
+    if ("V1" %in% colnames(dt)) dt[, V1 := NULL]
+    return(dt)
+  })
+})
+
+# Change scenario name to mifScenNames if applicable
+if (!is.null(params$mifScenNames)) {
+  loaded_files <- lapply(loaded_files, function(file_list) {
+    for (i in 1:length(params$mifScenNames)) {
+      file_list[[i]][, EDGE_scenario := params$mifScenNames[i]] 
+    } 
+    return(file_list)
+  })
+}
+# Combine the corresponding datasets across paths
+combined_files <- setNames(
+  lapply(files, function(file_name) {
+    do.call(rbind, loaded_files[[file_name]])
+  }),
+  files # This will set the names of the resulting list to the filenames
+)
+
+# Select relevant data for different files, based on "tall" column being in "timeResReporting"
+f29_trpdemand <- combined_files[["f29_trpdemand"]][tall %in% timeResReporting]
+f35_fe2es <- combined_files[["f35_fe2es"]][tall %in% timeResReporting]
+f35_esCapCost <- combined_files[["f35_esCapCost"]][tall %in% timeResReporting]
+f35_demByTech <- combined_files[["f35_demByTech"]][tall %in% timeResReporting]
+```
+
+# REMIND input data rom EDGE-T standalone comparison
+
+## Energy service demand on CES node level
+```{r trp_demand, echo=FALSE}
+unique_all_in <- unique(f29_trpdemand$all_in)
+
+# Loop through each unique value of all_teEs and create a plot
+for (allin in unique_all_in) {
+  
+  # Filter data for the current technology/service (all_teEs)
+  filtered_data <- f29_trpdemand[all_in == allin]
+  
+  # Create the ggplot for the current teEs
+  p <- ggplot(filtered_data, aes(x = tall, y = value, color = EDGE_scenario)) +
+    geom_line() +
+    facet_wrap(~ all_regi, scales = axisScaling) +  # Facet by region/country
+    labs(
+      title = paste("Energy service demand for:", allin),
+      x = "Time",
+      y = "Value",
+      color = "EDGE Scenario"
+    ) +
+    theme_minimal() +
+    theme(legend.position = "bottom")
+  
+  # Print the plot (or save it if you want to store the plots)
+  print(p)
+  
+  # Optionally, save the plot to a file
+  # ggsave(paste0("plot_", teEs, ".png"), plot = p, width = 8, height = 6)
+}
+
+```
+
+
+## Energy efficiency per energy service technology
+```{r fe2es, echo=FALSE}
+unique_teEs <- unique(f35_fe2es$all_teEs)
+
+# Loop through each unique value of all_teEs and create a plot
+for (teEs in unique_teEs) {
+  
+  # Filter data for the current technology/service (all_teEs)
+  filtered_data <- f35_fe2es[all_teEs == teEs, ]
+  
+  # Create the ggplot for the current teEs
+  p <- ggplot(filtered_data, aes(x = tall, y = value, color = EDGE_scenario)) +
+    geom_line() +
+    facet_wrap(~ all_regi, scales = axisScaling) +  # Facet by region/country
+    labs(
+      title = paste("Energy efficiency for:", teEs),
+      x = "Time",
+      y = "Value",
+      color = "EDGE Scenario"
+    ) +
+    theme_minimal() +
+    theme(legend.position = "bottom")
+  
+  # Print the plot (or save it if you want to store the plots)
+  print(p)
+  
+  # Optionally, save the plot to a file
+  # ggsave(paste0("plot_", teEs, ".png"), plot = p, width = 8, height = 6)
+}
+
+```
+
+
+## Capital cost per energy service technology
+```{r capital cost, echo=FALSE}
+unique_teEs <- unique(f35_esCapCost$all_teEs)
+
+# Loop through each unique value of all_teEs and create a plot
+for (teEs in unique_teEs) {
+  
+  # Filter data for the current technology/service (all_teEs)
+  filtered_data <- f35_esCapCost[all_teEs == teEs, ]
+  
+  # Create the ggplot for the current teEs
+  p <- ggplot(filtered_data, aes(x = tall, y = value, color = EDGE_scenario)) +
+    geom_line() +
+    facet_wrap(~ all_regi, scales = axisScaling) +  # Facet by region/country
+    labs(
+      title = paste("Capital cost for:", teEs),
+      x = "Time",
+      y = "Value",
+      color = "EDGE Scenario"
+    ) +
+    theme_minimal() +
+    theme(legend.position = "bottom")
+  
+  # Print the plot (or save it if you want to store the plots)
+  print(p)
+  
+  # Optionally, save the plot to a file
+  # ggsave(paste0("plot_", teEs, ".png"), plot = p, width = 8, height = 6)
+}
+
+```
+
+## Final energy demand per energy service technology
+```{r demByTech, echo=FALSE}
+unique_teEs <- unique(f35_demByTech$all_teEs)
+
+# Loop through each unique value of all_teEs and create a plot
+for (teEs in unique_teEs) {
+  
+  # Filter data for the current technology/service (all_teEs)
+  filtered_data <- f35_demByTech[all_teEs == teEs]
+  
+  # Create the ggplot for the current teEs
+  p <- ggplot(filtered_data, aes(x = tall, y = value, color = EDGE_scenario)) +
+    geom_line() +
+    facet_wrap(~ all_regi, scales = axisScaling) +  # Facet by region/country
+    labs(
+      title = paste("Capital cost for:", teEs),
+      x = "Time",
+      y = "Value",
+      color = "EDGE Scenario"
+    ) +
+    theme_minimal() +
+    theme(legend.position = "bottom")
+  
+  # Print the plot (or save it if you want to store the plots)
+  print(p)
+  
+  # Optionally, save the plot to a file
+  # ggsave(paste0("plot_", teEs, ".png"), plot = p, width = 8, height = 6)
+}
+
+```

--- a/inst/compareScenarios/cs_08_transportRemindInputfiles.Rmd
+++ b/inst/compareScenarios/cs_08_transportRemindInputfiles.Rmd
@@ -65,7 +65,7 @@ f35_esCapCost <- combined_files[["f35_esCapCost"]][tall %in% timeResReporting]
 f35_demByTech <- combined_files[["f35_demByTech"]][tall %in% timeResReporting]
 ```
 
-# REMIND input data rom EDGE-T standalone comparison
+# REMIND input data rom EDGE-T standalone
 
 ## Energy service demand on CES node level
 ```{r trp_demand, echo=FALSE}
@@ -73,11 +73,11 @@ unique_all_in <- unique(f29_trpdemand$all_in)
 
 # Loop through each unique value of all_teEs and create a plot
 for (allin in unique_all_in) {
-  
-  # Filter data for the current technology/service (all_teEs)
+
+  # Filter data for the current technology/service
   filtered_data <- f29_trpdemand[all_in == allin]
   
-  # Create the ggplot for the current teEs
+  # Create the ggplot for the current allin
   p <- ggplot(filtered_data, aes(x = tall, y = value, color = EDGE_scenario)) +
     geom_line() +
     facet_wrap(~ all_regi, scales = axisScaling) +  # Facet by region/country
@@ -90,11 +90,9 @@ for (allin in unique_all_in) {
     theme_minimal() +
     theme(legend.position = "bottom")
   
-  # Print the plot (or save it if you want to store the plots)
+  # Print the plot on a new page
   print(p)
-  
-  # Optionally, save the plot to a file
-  # ggsave(paste0("plot_", teEs, ".png"), plot = p, width = 8, height = 6)
+  cat("\n\n")
 }
 
 ```
@@ -106,7 +104,7 @@ unique_teEs <- unique(f35_fe2es$all_teEs)
 
 # Loop through each unique value of all_teEs and create a plot
 for (teEs in unique_teEs) {
-  
+
   # Filter data for the current technology/service (all_teEs)
   filtered_data <- f35_fe2es[all_teEs == teEs, ]
   
@@ -125,9 +123,7 @@ for (teEs in unique_teEs) {
   
   # Print the plot (or save it if you want to store the plots)
   print(p)
-  
-  # Optionally, save the plot to a file
-  # ggsave(paste0("plot_", teEs, ".png"), plot = p, width = 8, height = 6)
+  cat("\n\n")
 }
 
 ```
@@ -158,9 +154,7 @@ for (teEs in unique_teEs) {
   
   # Print the plot (or save it if you want to store the plots)
   print(p)
-  
-  # Optionally, save the plot to a file
-  # ggsave(paste0("plot_", teEs, ".png"), plot = p, width = 8, height = 6)
+  cat("\n\n")
 }
 
 ```
@@ -190,9 +184,7 @@ for (teEs in unique_teEs) {
   
   # Print the plot (or save it if you want to store the plots)
   print(p)
-  
-  # Optionally, save the plot to a file
-  # ggsave(paste0("plot_", teEs, ".png"), plot = p, width = 8, height = 6)
+  cat("\n\n")
 }
 
 ```

--- a/inst/compareScenarios/cs_08_transportRemindInputfiles.Rmd
+++ b/inst/compareScenarios/cs_08_transportRemindInputfiles.Rmd
@@ -18,6 +18,7 @@ timeResReporting <-  c(seq(2005, 2060, by = 5), seq(2070, 2100, by = 10))
 axisScaling = "free_y" #fixed
 paths = params$mifScen
 paths <- gsub("Transport.mif", "5_REMINDinputData", paths)
+print(paths)
 
 files <- list(f29_trpdemand = "f29_trpdemand",
               f35_demByTech = "f35_demByTech",
@@ -28,7 +29,7 @@ files <- list(f29_trpdemand = "f29_trpdemand",
 loaded_files <- lapply(files, function(file_name) {
   lapply(paths, function(path) {
     # Load the data using fread
-    if (file.exists(file.path(path, paste0(file_name, ".csv")))) fread(file.path(path, paste0(file_name, ".csv")))
+    if (file.exists(file.path(path, paste0(file_name, ".csv")))) fread(file.path(path,     paste0(file_name, ".csv")))
   })
 })
 

--- a/inst/compareScenarios/cs_08_transportRemindInputfiles.Rmd
+++ b/inst/compareScenarios/cs_08_transportRemindInputfiles.Rmd
@@ -5,13 +5,7 @@ date: "2024-09-05"
 output: html_document
 ---
 
-```{r setup, echo=FALSE}
-knitr::opts_chunk$set(echo = TRUE)
-
-```
-
-
-```{r preprocessing, echo=FALSE, message=FALSE, results='hide'}
+```{r preprocessing, echo=TRUE, message=TRUE}
 library(ggplot2)
 library(data.table)
 timeResReporting <-  c(seq(2005, 2060, by = 5), seq(2070, 2100, by = 10))
@@ -36,7 +30,9 @@ loaded_files <- lapply(files, function(file_name) {
 # Clean the loaded data by applying the required transformations
 loaded_files <- lapply(loaded_files, function(file_list) {
   lapply(file_list, function(dt) {
+    library(data.table)
     # If the column V1 exists, remove it
+    dt <- as.data.table(dt)
     if ("V1" %in% colnames(dt)) dt[, V1 := NULL]
     return(dt)
   })
@@ -69,7 +65,7 @@ f35_demByTech <- combined_files[["f35_demByTech"]][tall %in% timeResReporting]
 # REMIND input data rom EDGE-T standalone
 
 ## Energy service demand on CES node level
-```{r trp_demand, echo=FALSE}
+```{r trp_demand, echo=TRUE, message=TRUE}
 unique_all_in <- unique(f29_trpdemand$all_in)
 
 # Loop through each unique value of all_teEs and create a plot
@@ -100,7 +96,7 @@ for (allin in unique_all_in) {
 
 
 ## Energy efficiency per energy service technology
-```{r fe2es, echo=FALSE}
+```{r fe2es, echo=TRUE, message=TRUE}
 unique_teEs <- unique(f35_fe2es$all_teEs)
 
 # Loop through each unique value of all_teEs and create a plot
@@ -131,7 +127,7 @@ for (teEs in unique_teEs) {
 
 
 ## Capital cost per energy service technology
-```{r capital cost, echo=FALSE}
+```{r capital cost, echo=TRUE, message=TRUE}
 unique_teEs <- unique(f35_esCapCost$all_teEs)
 
 # Loop through each unique value of all_teEs and create a plot
@@ -161,7 +157,7 @@ for (teEs in unique_teEs) {
 ```
 
 ## Final energy demand per energy service technology
-```{r demByTech, echo=FALSE}
+```{r demByTech, echo=TRUE, message=TRUE}
 unique_teEs <- unique(f35_demByTech$all_teEs)
 
 # Loop through each unique value of all_teEs and create a plot

--- a/inst/compareScenarios/cs_08_transportRemindInputfiles.Rmd
+++ b/inst/compareScenarios/cs_08_transportRemindInputfiles.Rmd
@@ -5,14 +5,14 @@ date: "2024-09-05"
 output: html_document
 ---
 
-```{r preprocessing, echo=TRUE, message=TRUE}
+```{r}
 library(ggplot2)
-library(data.table)
+library(dplyr)
+
 timeResReporting <-  c(seq(2005, 2060, by = 5), seq(2070, 2100, by = 10))
 axisScaling = "free_y" #fixed
 paths = params$mifScen
 paths <- gsub("Transport.mif", "5_REMINDinputData", paths)
-print(paths)
 
 files <- list(f29_trpdemand = "f29_trpdemand",
               f35_demByTech = "f35_demByTech",
@@ -22,19 +22,18 @@ files <- list(f29_trpdemand = "f29_trpdemand",
 # Load files from all paths
 loaded_files <- lapply(files, function(file_name) {
   lapply(paths, function(path) {
-    # Load the data using fread
-    if (file.exists(file.path(path, paste0(file_name, ".csv")))) fread(file.path(path,     paste0(file_name, ".csv")))
+    # Load the data using read.csv
+    file_path <- file.path(path, paste0(file_name, ".csv"))
+    if (file.exists(file_path)) read.csv(file_path)
   })
 })
 
 # Clean the loaded data by applying the required transformations
 loaded_files <- lapply(loaded_files, function(file_list) {
-  lapply(file_list, function(dt) {
-    library(data.table)
+  lapply(file_list, function(df) {
     # If the column V1 exists, remove it
-    dt <- as.data.table(dt)
-    if ("V1" %in% colnames(dt)) dt[, V1 := NULL]
-    return(dt)
+    if ("V1" %in% colnames(df)) df <- df %>% select(-V1)
+    return(df)
   })
 })
 
@@ -42,37 +41,38 @@ loaded_files <- lapply(loaded_files, function(file_list) {
 if (!is.null(params$mifScenNames)) {
   loaded_files <- lapply(loaded_files, function(file_list) {
     for (i in 1:length(params$mifScenNames)) {
-      file_list[[i]][, EDGE_scenario := params$mifScenNames[i]] 
+      file_list[[i]] <- file_list[[i]] %>% mutate(EDGE_scenario = params$mifScenNames[i])
     } 
     return(file_list)
   })
 }
+
 # Combine the corresponding datasets across paths
 combined_files <- setNames(
   lapply(files, function(file_name) {
-    do.call(rbind, loaded_files[[file_name]])
+    bind_rows(loaded_files[[file_name]])
   }),
   files # This will set the names of the resulting list to the filenames
 )
 
 # Select relevant data for different files, based on "tall" column being in "timeResReporting"
-f29_trpdemand <- combined_files[["f29_trpdemand"]][tall %in% timeResReporting]
-f35_fe2es <- combined_files[["f35_fe2es"]][tall %in% timeResReporting]
-f35_esCapCost <- combined_files[["f35_esCapCost"]][tall %in% timeResReporting]
-f35_demByTech <- combined_files[["f35_demByTech"]][tall %in% timeResReporting]
+f29_trpdemand <- combined_files[["f29_trpdemand"]] %>% filter(tall %in% timeResReporting)
+f35_fe2es <- combined_files[["f35_fe2es"]] %>% filter(tall %in% timeResReporting)
+f35_esCapCost <- combined_files[["f35_esCapCost"]] %>% filter(tall %in% timeResReporting)
+f35_demByTech <- combined_files[["f35_demByTech"]] %>% filter(tall %in% timeResReporting)
 ```
 
 # REMIND input data rom EDGE-T standalone
 
 ## Energy service demand on CES node level
-```{r trp_demand, echo=TRUE, message=TRUE}
+```{r}
 unique_all_in <- unique(f29_trpdemand$all_in)
 
 # Loop through each unique value of all_teEs and create a plot
 for (allin in unique_all_in) {
 
   # Filter data for the current technology/service
-  filtered_data <- f29_trpdemand[all_in == allin]
+  filtered_data <- f29_trpdemand %>% filter(all_in == allin)
   
   # Create the ggplot for the current allin
   p <- ggplot(filtered_data, aes(x = tall, y = value, color = EDGE_scenario)) +
@@ -96,14 +96,14 @@ for (allin in unique_all_in) {
 
 
 ## Energy efficiency per energy service technology
-```{r fe2es, echo=TRUE, message=TRUE}
+```{r}
 unique_teEs <- unique(f35_fe2es$all_teEs)
 
 # Loop through each unique value of all_teEs and create a plot
 for (teEs in unique_teEs) {
 
   # Filter data for the current technology/service (all_teEs)
-  filtered_data <- f35_fe2es[all_teEs == teEs, ]
+  filtered_data <- f35_fe2es %>% filter(all_teEs == teEs)
   
   # Create the ggplot for the current teEs
   p <- ggplot(filtered_data, aes(x = tall, y = value, color = EDGE_scenario)) +
@@ -122,19 +122,18 @@ for (teEs in unique_teEs) {
   print(p)
   cat("\n\n")
 }
-
 ```
 
 
 ## Capital cost per energy service technology
-```{r capital cost, echo=TRUE, message=TRUE}
+```{r}
 unique_teEs <- unique(f35_esCapCost$all_teEs)
 
 # Loop through each unique value of all_teEs and create a plot
 for (teEs in unique_teEs) {
   
   # Filter data for the current technology/service (all_teEs)
-  filtered_data <- f35_esCapCost[all_teEs == teEs, ]
+  filtered_data <- f35_esCapCost %>% filter(all_teEs == teEs)
   
   # Create the ggplot for the current teEs
   p <- ggplot(filtered_data, aes(x = tall, y = value, color = EDGE_scenario)) +
@@ -157,14 +156,14 @@ for (teEs in unique_teEs) {
 ```
 
 ## Final energy demand per energy service technology
-```{r demByTech, echo=TRUE, message=TRUE}
+```{r}
 unique_teEs <- unique(f35_demByTech$all_teEs)
 
 # Loop through each unique value of all_teEs and create a plot
 for (teEs in unique_teEs) {
   
   # Filter data for the current technology/service (all_teEs)
-  filtered_data <- f35_demByTech[all_teEs == teEs]
+  filtered_data <- f35_demByTech %>% filter(all_teEs == teEs)
   
   # Create the ggplot for the current teEs
   p <- ggplot(filtered_data, aes(x = tall, y = value, color = EDGE_scenario)) +

--- a/man/reportLiquidsAndGasesComposition.Rd
+++ b/man/reportLiquidsAndGasesComposition.Rd
@@ -4,15 +4,13 @@
 \alias{reportLiquidsAndGasesComposition}
 \title{Report the split of liquids and gases into fossil|bio|hydrogen}
 \usage{
-reportLiquidsAndGasesComposition(dtFE, gdxPath, timeResReporting, helpers)
+reportLiquidsAndGasesComposition(dtFE, gdxPath, helpers)
 }
 \arguments{
 \item{dtFE}{Final energy data for liquids and gases}
 
 \item{gdxPath}{Path to REMIND gdx, which contains the share of the various production routes
 for liquid and gaseous energy carriers}
-
-\item{timeResReporting}{Time resolution for variable reporting}
 
 \item{helpers}{List of helpers}
 }

--- a/man/reportTransportVarSet.Rd
+++ b/man/reportTransportVarSet.Rd
@@ -4,14 +4,12 @@
 \alias{reportTransportVarSet}
 \title{Report detailed transport variable set}
 \usage{
-reportTransportVarSet(data, baseVarSet, timeResReporting)
+reportTransportVarSet(data, baseVarSet)
 }
 \arguments{
 \item{data}{List that contains the model results to report the detailed transport variable set}
 
 \item{baseVarSet}{Basic output variable set}
-
-\item{timeResReporting}{Timesteps to be reported}
 }
 \value{
 Detailed transport output variable set


### PR DESCRIPTION
This change includes:
- Small refactoring of the output file loading 
- Inclusion of standalone transport input data into the extended transport reporting
- Small rewrite of the regional aggregation to incorporate GDP
- Input data analysis sheet in the transport compScen
- REMIND input data reported by edget analysis sheet

**Motivation** for this was the problems we had with the unit shift.
The new sheets enable us to analyze the model behavior in detail.

**The next step** would be to add a sheet for the analysis of inconvenience costs. 
Needed variables are already reported in the transport.mif

Furthermore, it would be nice to aggregate intensive variables with their specific counterparts and not all with the energy service demand. 

The changes do not affect the results:
/p/projects/edget/PRchangeLog/20241024_unitShiftUSD2017adjustCAPEX_2w20241030_FlexibleUnitShift