### PR TITLE
remove double || in aggregated variables

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1406650'
+ValidationKey: '1427739'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -44,6 +44,13 @@ jobs:
           [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true
           [ -f requirements.txt ] && pip install -r requirements.txt || true
 
+      - name: Run pre-commit checks
+        shell: bash
+        run: |
+          python -m pip install pre-commit
+          python -m pip freeze --local
+          pre-commit run --show-diff-on-failure --color=always --all-files
+
       - name: Verify validation key
         shell: Rscript {0}
         run: lucode2:::validkey(stopIfInvalid = TRUE)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,4 +25,4 @@ repos:
     -   id: readme-rmd-rendered
     -   id: use-tidy-description
 ci:
-    autoupdate_schedule: quarterly
+    autoupdate_schedule: weekly

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'reporttransport: Reporting package for edgeTransport'
-version: 0.7.0
-date-released: '2025-01-07'
+version: 0.7.1
+date-released: '2025-01-21'
 abstract: This package contains edgeTransport-specific routines to report model results.
   The main functionality is to generate transport reporting variables in MIF format
   from a given edgeTransport model run folder or REMIND input data.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: reporttransport
 Title: Reporting package for edgeTransport
-Version: 0.7.0
-Date: 2025-01-07
+Version: 0.7.1
+Date: 2025-01-21
 Authors@R:
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre"))
 Description: This package contains edgeTransport-specific routines to

--- a/R/aggregateVariables.R
+++ b/R/aggregateVariables.R
@@ -266,7 +266,7 @@ aggregateVariables <- function(vars, mapAggregation, weight = NULL) {
   aggrvars[grepl("US\\$2017/pkm|US\\$2017/tkm", unit), unit := "US$2017/(p|t)km"]
   byCols <- c("region", "technology", "fuel", "variable", "unit", "period")
   aggrvars <- aggregateLevel(aggrvars, byCols, weight)
-  aggrvars[, variable := paste0(variable, "|Transport|Rail", technology, "|", fuel)][, c("technology", "fuel") := NULL]
+  aggrvars[, variable := paste0(variable, "|Transport|Rail", technology, fuel)][, c("technology", "fuel") := NULL]
   aggregatedvars <- rbind(aggregatedvars, aggrvars)
 
   # Aggregate aviation --------------------------------------------------------------------
@@ -288,7 +288,7 @@ aggregateVariables <- function(vars, mapAggregation, weight = NULL) {
   aggrvars <- aggrvars[grepl(".*Aviation.*", subsectorL1) & !is.na(fuel)]
   byCols <- c("region", "technology", "fuel", "variable", "unit", "period")
   aggrvars <- aggregateLevel(aggrvars, byCols, weight)
-  aggrvars[, variable := paste0(variable, "|Transport|Pass|Aviation", technology, "|", fuel)][, c("technology", "fuel") := NULL]
+  aggrvars[, variable := paste0(variable, "|Transport|Pass|Aviation", technology, fuel)][, c("technology", "fuel") := NULL]
   aggregatedvars <- rbind(aggregatedvars, aggrvars)
 
   if (anyNA(aggregatedvars)) stop("Output variable contains NAs.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reporting package for edgeTransport
 
-R package **reporttransport**, version **0.7.0**
+R package **reporttransport**, version **0.7.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/reporttransport)](https://cran.r-project.org/package=reporttransport) [![R build status](https://github.com/pik-piam/reporttransport/workflows/check/badge.svg)](https://github.com/pik-piam/reporttransport/actions) [![codecov](https://codecov.io/gh/pik-piam/reporttransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/reporttransport) [![r-universe](https://pik-piam.r-universe.dev/badges/reporttransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -41,15 +41,17 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **reporttransport** in publications use:
 
-Hoppe J (2025). "reporttransport: Reporting package for edgeTransport - Version 0.7.0."
+Hoppe J (2025). "reporttransport: Reporting package for edgeTransport." Version: 0.7.1, <https://github.com/pik-piam/reporttransport>.
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {reporttransport: Reporting package for edgeTransport - Version 0.7.0},
+  title = {reporttransport: Reporting package for edgeTransport},
   author = {Johanna Hoppe},
-  date = {2025-01-07},
+  date = {2025-01-21},
   year = {2025},
+  url = {https://github.com/pik-piam/reporttransport},
+  note = {Version: 0.7.1},
 }
 ```


### PR DESCRIPTION
## Purpose of this PR

- close https://github.com/pik-piam/transportIssues/issues/26
- I ran REMIND reporting with it and the error went away. Is that sufficient?

## Checklist:

- [ ] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

