### PR TITLE
QuickFix to reduce temporal scope

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '1634661'
+ValidationKey: '1660418'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'reporttransport: Reporting package for edgeTransport'
-version: 0.8.1
-date-released: '2025-04-03'
+version: 0.8.2
+date-released: '2025-06-10'
 abstract: This package contains edgeTransport-specific routines to report model results.
   The main functionality is to generate transport reporting variables in MIF format
   from a given edgeTransport model run folder or REMIND input data.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: reporttransport
 Title: Reporting package for edgeTransport
-Version: 0.8.1
-Date: 2025-04-03
+Version: 0.8.2
+Date: 2025-06-10
 Authors@R:
     c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/reportEdgeTransport.R
+++ b/R/reportEdgeTransport.R
@@ -162,7 +162,7 @@ reportEdgeTransport <- function(folderPath = file.path(".", "EDGE-T"), data = NU
   #########################################################################
   # If you want to change timeResReporting to timesteps outside the modeleled timesteps,
   # please add an interpolation step
-  timeResReporting <-  c(seq(2005, 2060, by = 5), seq(2070, 2110, by = 10), 2130, 2150)
+  timeResReporting <-  c(seq(2015, 2060, by = 5), seq(2070, 2110, by = 10), 2130, 2150)
   # Apply time resolution that should be reported
   data <- lapply(data, applyReportingTimeRes, timeResReporting)
   baseVarSet <- lapply(baseVarSet, applyReportingTimeRes, timeResReporting)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reporting package for edgeTransport
 
-R package **reporttransport**, version **0.8.1**
+R package **reporttransport**, version **0.8.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/reporttransport)](https://cran.r-project.org/package=reporttransport) [![R build status](https://github.com/pik-piam/reporttransport/workflows/check/badge.svg)](https://github.com/pik-piam/reporttransport/actions) [![codecov](https://codecov.io/gh/pik-piam/reporttransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/reporttransport) [![r-universe](https://pik-piam.r-universe.dev/badges/reporttransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -41,17 +41,15 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **reporttransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A (2025). "reporttransport: Reporting package for edgeTransport." Version: 0.8.1, <https://github.com/pik-piam/reporttransport>.
+Hoppe J, Muessel J, Hagen A (2025). "reporttransport: Reporting package for edgeTransport - Version 0.8.2."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {reporttransport: Reporting package for edgeTransport},
+  title = {reporttransport: Reporting package for edgeTransport - Version 0.8.2},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen},
-  date = {2025-04-03},
+  date = {2025-06-10},
   year = {2025},
-  url = {https://github.com/pik-piam/reporttransport},
-  note = {Version: 0.8.1},
 }
 ```


### PR DESCRIPTION
I don't need a review from all of you, I just added all of you to inform you about the PR.

## Purpose of this PR
[General issue: summation checks fail](https://github.com/pik-piam/transportIssues/issues/30), which needsa  long-term solution.

[Decision ](https://github.com/remindmodel/development_issues/issues/558) to do a quick fix for scenarioMip, which needs to be reverted in the long term.

Solution: Don't report 2005 and 2010, since the biggest differences are in these two time steps.


## Checklist:

- [x] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 
`/p/projects/edget/PRchangeLog/20250610_reportTrTimeSteps´
