### PR TITLE
Bugfix outputdir path dependency

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2691133'
+ValidationKey: '2718540'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -11,37 +11,22 @@ jobs:
   check:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    container:
+      image: ghcr.io/pik-piam/ci-image:latest
 
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-          extra-repositories: "https://rse.pik-potsdam.de/r/packages"
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            lucode2
-            covr
-            madrat
-            magclass
-            citation
-            gms
-            goxygen
-            GDPuc
-          # piam packages also available on CRAN (madrat, magclass, citation,
-          # gms, goxygen, GDPuc) will usually have an outdated binary version
-          # available; by using extra-packages we get the newest version
+      - name: Install package and dependencies
+        shell: Rscript {0}
+        run: |
+          options(repos = c(pikpiam = 'https://pik-piam.r-universe.dev',
+                            CRAN = Sys.getenv('RSPM')))
+          pak::pak()
 
       - name: Run pre-commit checks
         shell: bash
         run: |
-          python -m pip install pre-commit
-          python -m pip freeze --local
           pre-commit run --show-diff-on-failure --color=always --all-files
 
       - name: Verify validation key

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: 3b70240796cdccbe1474b0176560281aaded97e6  # frozen: v0.4.3.9003
+    rev: v0.4.3.9021
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'reporttransport: Reporting package for edgeTransport'
-version: 1.3.1
-date-released: '2026-03-31'
+version: 1.3.2
+date-released: '2026-05-22'
 abstract: This package contains edgeTransport-specific routines to report model results.
   The main functionality is to generate transport reporting variables in MIF format
   from a given edgeTransport model run folder or REMIND input data.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: reporttransport
 Title: Reporting package for edgeTransport
-Version: 1.3.1
-Date: 2026-03-31
+Version: 1.3.2
+Date: 2026-05-22
 Authors@R:
     c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/checkConvergence.R
+++ b/R/checkConvergence.R
@@ -1,15 +1,16 @@
 #' Compare parameters in edget and REMIND and store their deviation to track model convergence
 #'
+#' @param outputdir path to REMIND outputfolder
 #' @author Johanna Hoppe
 #' @export
 
-checkConvergence <- function() {
+checkConvergence <- function(outputdir) {
 #---------------------------------------------------
-# in a remind run the runfolder is the working dircetory
-load("config.Rdata")
+
+load(file.path(outputdir, "config.Rdata"))
 
 # ---- load data ----
-gdx <- "fulldata.gdx"
+gdx <- file.path(outputdir,"fulldata.gdx")
 mapEdgeToREMIND <- fread(system.file("extdata/helpersMappingEdgeTtoREMINDcategories.csv",
                                      package = "edgeTransport", mustWork = TRUE))
 mapEdgeToREMIND <- mapEdgeToREMIND[!is.na(all_teEs)]
@@ -21,12 +22,13 @@ timeResReporting <- c(seq(1900,1985,5),
                       2130, 2150)
 transportPolScen <- cfg$gms$cm_EDGEtr_scen
 
+data <- list()
 # Load edge-t data from runfolder
 filesToLoad <- c("hybridElecShare",
                  "helpers")
 
 if (length(filesToLoad) > 0) {
-  filePaths <- list.files("./EDGE-T", recursive = TRUE, full.names = TRUE)
+  filePaths <- list.files(file.path(outputdir, "EDGE-T"), recursive = TRUE, full.names = TRUE)
   pathFilesToLoad <- unlist(lapply(filesToLoad, function(x) {filePaths[grepl(paste0(x, ".RDS"), filePaths)]}))
   itemNames <- basename(pathFilesToLoad)
   itemNames <- sub("\\.RDS$", "", itemNames)
@@ -35,12 +37,11 @@ if (length(filesToLoad) > 0) {
   data <- c(data, addFiles)
 }
 
-baseOutput <- reportEdgeTransport("./EDGE-T",
+baseOutput <- reportEdgeTransport(file.path(outputdir, "EDGE-T"),
                                   isTransportReported = FALSE)
 
 fleetESdemand <- baseOutput$ext$fleetESdemand
 fleetFEdemand <- baseOutput$ext$fleetFEdemand
-
 
 # ---- Energy intensity ----
   # 1: pm_fe2es Energy intensity of transport nodes parameter from the last REMIND iteration -> REMIND_val
@@ -88,7 +89,7 @@ fleetFEdemand <- baseOutput$ext$fleetFEdemand
   testEnergyIntensity[, percentRelativeToEDGET := abs(REMINDvalue - EDGEvalue)/EDGEvalue][, variable := "Energy Intensity"][, comparison := "Deviation last iteration REMIND vs last iteration EDGE-T"]
   numericCols <- c("REMINDvalue", "EDGEvalue", "deviationAbsolute", "percentRelativeToEDGET")
   testEnergyIntensity[, (numericCols) := lapply(.SD, function(x) sprintf("%.2E", signif(x, 6))), .SDcols = numericCols]
-  utils::write.table(testEnergyIntensity, file.path("EDGE-T", "trackREMINDvsEDGETparameterEnergyIntensity.csv"), row.names = FALSE, sep = ";", quote = FALSE)
+  utils::write.table(testEnergyIntensity, file.path(outputdir, "EDGE-T", "trackREMINDvsEDGETparameterEnergyIntensity.csv"), row.names = FALSE, sep = ";", quote = FALSE)
   setnames(testEnergyIntensity, "all_teEs", "REMINDset")
 # ---- Energy service demand ----
 
@@ -144,7 +145,7 @@ fleetFEdemand <- baseOutput$ext$fleetFEdemand
   numericCols <- c("REMINDcesIO", "SumREMINDprodEs", "REMINDtoEDGEes", "EDGEtoREMINDes", "deviationAbsolute", "percentRelativeToEDGET")
   testES[, (numericCols) := lapply(.SD, function(x) sprintf("%.2E", signif(x, 6))), .SDcols = numericCols]
   testES[, variable := "Energy service demand"]
-  utils::write.table(testES, file.path("EDGE-T", "trackREMINDvsEDGETparameterEnergyService.csv"), row.names = FALSE, sep = ";", quote = FALSE)
+  utils::write.table(testES, file.path(outputdir, "EDGE-T", "trackREMINDvsEDGETparameterEnergyService.csv"), row.names = FALSE, sep = ";", quote = FALSE)
   setnames(testES, "all_in", "REMINDset")
 
   trackConvergence <- rbind(testEnergyIntensity[, c("all_regi", "tall", "REMINDset", "deviationAbsolute", "percentRelativeToEDGET", "comparison", "variable")],
@@ -152,5 +153,5 @@ fleetFEdemand <- baseOutput$ext$fleetFEdemand
   # Only report outliers that deviate more than 1% from EDGE-T value
   trackConvergence <- trackConvergence[percentRelativeToEDGET > 0.5]
 
-  utils::write.table(trackConvergence, file.path("EDGE-T", "trackConvergence.csv"), row.names = FALSE, sep = ";", quote = FALSE)
+  utils::write.table(trackConvergence, file.path(outputdir, "EDGE-T", "trackConvergence.csv"), row.names = FALSE, sep = ";", quote = FALSE)
 }

--- a/R/harmonizeREMINDvsEDGETenergyServiceDemand.R
+++ b/R/harmonizeREMINDvsEDGETenergyServiceDemand.R
@@ -8,6 +8,7 @@
 #' Therefore, we don't want to take the fuel prices from the last REMIND iteration and keep the vehicle sales and mode shares/stock composition as they are
 #' Deviations are stored in EDGE-T/trackConvergence.csv (parameter) checkREMINDvsEDGETmifVariables.csv (mif variables)
 
+#' @param gdx path to REMIND fulldata.gdx
 #' @param ESdemandFVsalesLevel Energy service demand on sales level
 #' @param fleetESdemand Energy service demand on fleet level
 #' @param helpers EDGE-T helpers that include e.g. the decision tree
@@ -15,9 +16,9 @@
 #' @author Johanna Hoppe
 #' @export
 
-harmonizeREMINDvsEDGETenergyServiceDemand <- function(ESdemandFVsalesLevel, fleetESdemand, helpers) {
+harmonizeREMINDvsEDGETenergyServiceDemand <- function(gdx, ESdemandFVsalesLevel, fleetESdemand, helpers) {
+
   # Read in energy service demand from last REMIND iteration
-  gdx <- file.path(".", "fulldata.gdx")
   harmREMINDdemand <- edgeTransport::toolLoadREMINDesDemand(gdx, helpers)
   setnames(harmREMINDdemand, "value", "harmREMINDdemand")
   ESdemandFVfleetLevel <- rbind(ESdemandFVsalesLevel[!grepl("Bus.*|.*4W|.*freight_road.*", subsectorL3)],

--- a/R/reportEdgeTransport.R
+++ b/R/reportEdgeTransport.R
@@ -120,6 +120,8 @@ reportEdgeTransport <- function(folderPath = file.path(".", "EDGE-T"), data = NU
     data$gdxPath <- gdxPath
   }
 
+
+
   if (length(filesToLoad) > 0) {
     filePaths <- list.files(folderPath, recursive = TRUE, full.names = TRUE)
     pathFilesToLoad <- unlist(lapply(filesToLoad, function(x) {filePaths[grepl(paste0(x, ".RDS"), filePaths)]}))
@@ -137,7 +139,7 @@ reportEdgeTransport <- function(folderPath = file.path(".", "EDGE-T"), data = NU
   if (isHarmonized) {
     #The energy Service demand on REMIND CES leave level (pass_sm, freight_sm, pass_long, freight_long) is read in again from the last REMIND run and the energy service demand on fleet level in edget is rescaled to match it. Every other input is kept as it was before.
     #As the reporting of FE, emissions and total cost variables depends on the ES demands, this then automatically rescales the edget-reported FE, emissions and total cost with the same ratio of (final REMIND run ES) : (final edget run ES)
-    harmESdemandFV <- harmonizeREMINDvsEDGETenergyServiceDemand(ESdemandFVsalesLevel = data$ESdemandFVsalesLevel,
+    harmESdemandFV <- harmonizeREMINDvsEDGETenergyServiceDemand(gdx = data$gdxPath, ESdemandFVsalesLevel = data$ESdemandFVsalesLevel,
                                                                 fleetESdemand = data$fleetSizeAndComposition$fleetESdemand,
                                                                 helpers = data$helpers)
     # Replace unharmonized data
@@ -237,9 +239,10 @@ reportEdgeTransport <- function(folderPath = file.path(".", "EDGE-T"), data = NU
       remindEDGEvarMap <- remindEDGEvarMap[!is.na(variable)]
       if (nrow(remindEDGEvarMap) > 0) {
         #Load REMIND reporting
-        mifs <- list.files(".", recursive = FALSE, full.names = TRUE)
+        mifs <- list.files(dirname(folderPath), recursive = FALSE, full.names = TRUE)
         mif <- mifs[grepl(".*withoutPlus\\.mif", mifs)]
         #Select matching variables
+
         REMINDvars <- as.data.table(read.quitte(mif))
         setnames(REMINDvars, c("variable", "value"),
                  c("REMINDvar", "REMINDval"))
@@ -257,7 +260,7 @@ reportEdgeTransport <- function(folderPath = file.path(".", "EDGE-T"), data = NU
         setnames(test, "value", "EDGEval")
         numericCols <- c("REMINDval", "EDGEval", "deviationAbsolute", "percentRelativeToREMIND")
         test[, (numericCols) := lapply(.SD, function(x) sprintf("%.2E", signif(x, 6))), .SDcols = numericCols]
-        utils::write.table(test, file.path("EDGE-T", "checkREMINDvsEDGETmifVariables.csv"), row.names = FALSE, sep = ";", quote = FALSE)
+        utils::write.table(test, file.path(folderPath, "checkREMINDvsEDGETmifVariables.csv"), row.names = FALSE, sep = ";", quote = FALSE)
         # Variables reported by edgeTRansport that should be removed in the REMIND mif to avoid confusion/duplicates
         # 1. Remove duplicates that are reported by remind2 already + 2. variables that do not have an remind2 equivalent
         # but follow a different naming convention (e.g. FE|Transport|Pass includes bunkers in remind2 and not in reporttransport)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Reporting package for edgeTransport
 
-R package **reporttransport**, version **1.3.1**
+R package **reporttransport**, version **1.3.2**
 
-[![CRAN status](https://www.r-pkg.org/badges/version/reporttransport)](https://cran.r-project.org/package=reporttransport) [![R build status](https://github.com/pik-piam/reporttransport/workflows/check/badge.svg)](https://github.com/pik-piam/reporttransport/actions) [![codecov](https://codecov.io/gh/pik-piam/reporttransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/reporttransport) [![r-universe](https://pik-piam.r-universe.dev/badges/reporttransport)](https://pik-piam.r-universe.dev/builds)
+   [![R build status](https://github.com/pik-piam/reporttransport/workflows/check/badge.svg)](https://github.com/pik-piam/reporttransport/actions) [![codecov](https://codecov.io/gh/pik-piam/reporttransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/reporttransport) [![r-universe](https://pik-piam.r-universe.dev/badges/reporttransport)](https://pik-piam.r-universe.dev/builds)
 
 ## Purpose and Functionality
 
@@ -23,13 +23,13 @@ The additional repository can be made available permanently by adding the line a
 
 After that the most recent version of the package can be installed using `install.packages`:
 
-```r 
+```r
 install.packages("reporttransport")
 ```
 
 Package updates can be installed using `update.packages` (make sure that the additional repository has been added before running that command):
 
-```r 
+```r
 update.packages()
 ```
 
@@ -41,7 +41,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **reporttransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A (2026). "reporttransport: Reporting package for edgeTransport." Version: 1.3.1, <https://github.com/pik-piam/reporttransport>.
+Hoppe J, Muessel J, Hagen A (2026). "reporttransport: Reporting package for edgeTransport." Version: 1.3.2, <https://github.com/pik-piam/reporttransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -49,9 +49,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {reporttransport: Reporting package for edgeTransport},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen},
-  date = {2026-03-31},
+  date = {2026-05-22},
   year = {2026},
   url = {https://github.com/pik-piam/reporttransport},
-  note = {Version: 1.3.1},
+  note = {Version: 1.3.2},
 }
 ```

--- a/inst/helpersCommonVarsEDGETremind.csv
+++ b/inst/helpersCommonVarsEDGETremind.csv
@@ -98,9 +98,9 @@ FE|Transport|w/o Bunkers|Liquids|Biomass                 ;NA
 FE|Transport|w/o Bunkers|Liquids|Fossil                  ;NA
 FE|Transport|w/o Bunkers|Liquids|Hydrogen                ;NA
 SE|Input|Electricity|Transport;NA
-Emi|CO2|Energy|Demand|Transport|w/o bunkers;Emi|CO2|Energy|Demand|Transport
+Emi|CO2|w/o Bunkers|Energy|Demand|Transport;Emi|CO2|Energy|Demand|Transport
 Emi|CO2|Energy|Demand|Transport|International Bunkers;Emi|CO2|Energy|Demand|Transport|Bunkers
-Emi|CO2|Energy|Demand|Transport|w/ bunkers;Emi|CO2|Energy|Demand|Transport with bunkers
+Emi|CO2|w/ Bunkers|Energy|Demand|Transport;Emi|CO2|Energy|Demand|Transport with bunkers
 Emi|CO2|Energy|Demand|Transport;NA
 Emi|CO2|Energy|Demand|Transport|Gases;Emi|CO2|Energy|Demand|Transport with bunkers|Gases
 Emi|CO2|Energy|Demand|Transport|Liquids;Emi|CO2|Energy|Demand|Transport with bunkers|Liquids

--- a/man/checkConvergence.Rd
+++ b/man/checkConvergence.Rd
@@ -4,7 +4,10 @@
 \alias{checkConvergence}
 \title{Compare parameters in edget and REMIND and store their deviation to track model convergence}
 \usage{
-checkConvergence()
+checkConvergence(outputdir)
+}
+\arguments{
+\item{outputdir}{path to REMIND outputfolder}
 }
 \description{
 Compare parameters in edget and REMIND and store their deviation to track model convergence

--- a/man/harmonizeREMINDvsEDGETenergyServiceDemand.Rd
+++ b/man/harmonizeREMINDvsEDGETenergyServiceDemand.Rd
@@ -13,12 +13,15 @@ Therefore, we don't want to take the fuel prices from the last REMIND iteration 
 Deviations are stored in EDGE-T/trackConvergence.csv (parameter) checkREMINDvsEDGETmifVariables.csv (mif variables)}
 \usage{
 harmonizeREMINDvsEDGETenergyServiceDemand(
+  gdx,
   ESdemandFVsalesLevel,
   fleetESdemand,
   helpers
 )
 }
 \arguments{
+\item{gdx}{path to REMIND fulldata.gdx}
+
 \item{ESdemandFVsalesLevel}{Energy service demand on sales level}
 
 \item{fleetESdemand}{Energy service demand on fleet level}


### PR DESCRIPTION
## Purpose of this PR
This PR is a bugfix for the missing outputdir path dependency in https://github.com/remindmodel/remind/pull/2320
## Checklist:

- [ ] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):

This PR only affects the variable harmonization after REMIND runs. I tested the changes by rerunning the reporting for my REMIND runs here /p/projects/edget/ICEbanJohanna/remind 

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

