### PR TITLE
include 2W and 3W Stock and Sales in reporting

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2718540'
+ValidationKey: '2888200'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'reporttransport: Reporting package for edgeTransport'
-version: 1.3.2
-date-released: '2026-05-22'
+version: 1.4.0
+date-released: '2026-06-26'
 abstract: This package contains edgeTransport-specific routines to report model results.
   The main functionality is to generate transport reporting variables in MIF format
   from a given edgeTransport model run folder or REMIND input data.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: reporttransport
 Title: Reporting package for edgeTransport
-Version: 1.3.2
-Date: 2026-05-22
+Version: 1.4.0
+Date: 2026-06-26
 Authors@R:
     c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/reportBaseVarSet.R
+++ b/R/reportBaseVarSet.R
@@ -20,7 +20,7 @@ reportBaseVarSet <- function(data) {
   # (in the variables named fleet other modes are still included)
   # Energy service demand on fleet level deviates from the sales level
   # regarding the share that each technology gets
-  fleetESdemand <- rbind(data$ESdemandFVsalesLevel[!grepl("Bus.*|.*4W|.*freight_road.*", subsectorL3)],
+  fleetESdemand <- rbind(data$ESdemandFVsalesLevel[!grepl("Bus.*|.*4W|.*2W|.*3W|.*freight_road.*", subsectorL3)],
                          data$fleetSizeAndComposition$fleetESdemand)
   # Energy intensity and Capital costs are tied to the construction year and have to be recalculated
   # to reflect the value for each year referring to the vehicle stock

--- a/R/reportEdgeTransport.R
+++ b/R/reportEdgeTransport.R
@@ -42,7 +42,6 @@
 reportEdgeTransport <- function(folderPath = file.path(".", "EDGE-T"), data = NULL, isTransportReported = TRUE,
                                 isTransportExtendedReported = FALSE, isAnalyticsReported = FALSE,
                                 isREMINDinputReported = FALSE, isStored = TRUE, isHarmonized = FALSE, ...) {
-
   applyReportingTimeRes <- function(item, timeRes) {
     if (typeof(item) %in% c("character", "double") | "decisionTree" %in% names(item)) return(item)
     else if (is.data.table(item) & ("period" %chin% colnames(item))) item <- item[period %in% timeRes]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reporting package for edgeTransport
 
-R package **reporttransport**, version **1.3.2**
+R package **reporttransport**, version **1.4.0**
 
    [![R build status](https://github.com/pik-piam/reporttransport/workflows/check/badge.svg)](https://github.com/pik-piam/reporttransport/actions) [![codecov](https://codecov.io/gh/pik-piam/reporttransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/reporttransport) [![r-universe](https://pik-piam.r-universe.dev/badges/reporttransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -41,7 +41,7 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **reporttransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A (2026). "reporttransport: Reporting package for edgeTransport." Version: 1.3.2, <https://github.com/pik-piam/reporttransport>.
+Hoppe J, Muessel J, Hagen A (2026). "reporttransport: Reporting package for edgeTransport." Version: 1.4.0, <https://github.com/pik-piam/reporttransport>.
 
 A BibTeX entry for LaTeX users is
 
@@ -49,9 +49,9 @@ A BibTeX entry for LaTeX users is
 @Misc{,
   title = {reporttransport: Reporting package for edgeTransport},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen},
-  date = {2026-05-22},
+  date = {2026-06-26},
   year = {2026},
   url = {https://github.com/pik-piam/reporttransport},
-  note = {Version: 1.3.2},
+  note = {Version: 1.4.0},
 }
 ```

--- a/inst/compareScenarios/cs_04_stock_and_sales.Rmd
+++ b/inst/compareScenarios/cs_04_stock_and_sales.Rmd
@@ -1,6 +1,6 @@
 # Stock and Sales
 
-## LDV Stock by vehicle size
+## LDV 4W Stock by vehicle size
 ```{r}
 tot <- "Stock|Transport|Pass|Road|LDV|Four Wheelers"
 items <- c("Stock|Transport|Pass|Road|LDV|Four Wheelers|Large|Large Car",
@@ -15,7 +15,7 @@ showAreaAndBarPlots(data, items, tot, orderVars = "user")
 showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```
 
-## LDV Sales by vehicle size 
+## LDV 4W Sales by vehicle size
 ```{r}
 tot <- "Sales|Transport|Pass|Road|LDV|Four Wheelers"
 items <- c("Sales|Transport|Pass|Road|LDV|Four Wheelers|Large|Large Car",
@@ -98,6 +98,66 @@ items <- c("Sales|Transport|Pass|Road|LDV|Four Wheelers|Large|Large Car and SUV|
            "Sales|Transport|Pass|Road|LDV|Four Wheelers|Large|Large Car and SUV|Hybrid electric",
            "Sales|Transport|Pass|Road|LDV|Four Wheelers|Large|Large Car and SUV|Liquids",
            "Sales|Transport|Pass|Road|LDV|Four Wheelers|Large|Large Car and SUV|Gases")
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
+```
+
+## 2W Stock by vehicle size
+```{r}
+tot <- "Stock|Transport|Pass|Road|LDV|Two Wheelers"
+items <- c("Stock|Transport|Pass|Road|LDV|Three Wheelers",
+           "Stock|Transport|Pass|Road|LDV|Two Wheelers|Motorcycle(>250cc)",
+           "Stock|Transport|Pass|Road|LDV|Two Wheelers|Motorcycle(50-250cc)",
+           "Stock|Transport|Pass|Road|LDV|Two Wheelers|Moped"
+           )
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
+```
+
+## 2W Sales by vehicle size
+```{r}
+tot <- "Sales|Transport|Pass|Road|LDV|Two Wheelers"
+items <- c("Sales|Transport|Pass|Road|LDV|Three Wheelers",
+           "Sales|Transport|Pass|Road|LDV|Two Wheelers|Motorcycle(>250cc)",
+           "Sales|Transport|Pass|Road|LDV|Two Wheelers|Motorcycle(50-250cc)",
+           "Sales|Transport|Pass|Road|LDV|Two Wheelers|Moped"
+           )
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
+```
+
+## 2W Stock by technology
+```{r}
+tot <- "Stock|Transport|Pass|Road|LDV|Two Wheelers"
+items <- c("Stock|Transport|Pass|Road|LDV|Two Wheelers|BEV",
+           "Stock|Transport|Pass|Road|LDV|Two Wheelers|Liquids")
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
+```
+
+## 2W Sales by technology
+```{r}
+tot <- "Sales|Transport|Pass|Road|LDV|Two Wheelers"
+items <- c("Sales|Transport|Pass|Road|LDV|Two Wheelers|BEV",
+           "Sales|Transport|Pass|Road|LDV|Two Wheelers|Liquids")
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
+```
+
+## 3W Stock by technology
+```{r}
+tot <- "Stock|Transport|Pass|Road|LDV|Three Wheelers"
+items <- c("Stock|Transport|Pass|Road|LDV|Three Wheelers|BEV",
+           "Stock|Transport|Pass|Road|LDV|Three Wheelers|Liquids")
+showAreaAndBarPlots(data, items, tot, orderVars = "user")
+showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
+```
+
+## 3W Sales by technology
+```{r}
+tot <- "Sales|Transport|Pass|Road|LDV|Three Wheelers"
+items <- c("Sales|Transport|Pass|Road|LDV|Three Wheelers|BEV",
+           "Sales|Transport|Pass|Road|LDV|Three Wheelers|Liquids")
 showAreaAndBarPlots(data, items, tot, orderVars = "user")
 showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ```


### PR DESCRIPTION
## Purpose of this PR

This PR is related to [PR 409 in edgeTransport](https://github.com/pik-piam/edgeTransport/pull/409)

## Checklist:

- [x] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):

* Test runs are here: `20260626_PR_409_add23Wfleet`
* Comparison of results (what changes by this PR?): 

