### PR TITLE
bugFix harmonizeES and plotFix

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2888200'
+ValidationKey: '2911227'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'reporttransport: Reporting package for edgeTransport'
-version: 1.4.0
-date-released: '2026-06-26'
+version: 1.4.1
+date-released: '2026-07-13'
 abstract: This package contains edgeTransport-specific routines to report model results.
   The main functionality is to generate transport reporting variables in MIF format
   from a given edgeTransport model run folder or REMIND input data.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: reporttransport
 Title: Reporting package for edgeTransport
-Version: 1.4.0
-Date: 2026-06-26
+Version: 1.4.1
+Date: 2026-07-13
 Authors@R:
     c(
     person("Johanna", "Hoppe", , "johanna.hoppe@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/harmonizeREMINDvsEDGETenergyServiceDemand.R
+++ b/R/harmonizeREMINDvsEDGETenergyServiceDemand.R
@@ -21,7 +21,7 @@ harmonizeREMINDvsEDGETenergyServiceDemand <- function(gdx, ESdemandFVsalesLevel,
   # Read in energy service demand from last REMIND iteration
   harmREMINDdemand <- edgeTransport::toolLoadREMINDesDemand(gdx, helpers)
   setnames(harmREMINDdemand, "value", "harmREMINDdemand")
-  ESdemandFVfleetLevel <- rbind(ESdemandFVsalesLevel[!grepl("Bus.*|.*4W|.*freight_road.*", subsectorL3)],
+  ESdemandFVfleetLevel <- rbind(ESdemandFVsalesLevel[!grepl("Bus.*|.*4W|.*2W|.*3W|.*freight_road.*", subsectorL3)],
                          fleetESdemand)
   #Change regional resolution to caluclate harmonizationfactors if necessary
   if (length(unique(harmREMINDdemand$region)) == 12) {

--- a/R/reportEdgeTransport.R
+++ b/R/reportEdgeTransport.R
@@ -121,6 +121,8 @@ reportEdgeTransport <- function(folderPath = file.path(".", "EDGE-T"), data = NU
 
 
 
+
+
   if (length(filesToLoad) > 0) {
     filePaths <- list.files(folderPath, recursive = TRUE, full.names = TRUE)
     pathFilesToLoad <- unlist(lapply(filesToLoad, function(x) {filePaths[grepl(paste0(x, ".RDS"), filePaths)]}))
@@ -146,7 +148,7 @@ reportEdgeTransport <- function(folderPath = file.path(".", "EDGE-T"), data = NU
     # Overwrite the full data on sales level with the harmonized data on fleet level
     data$ESdemandFVsalesLevel <- harmESdemandFV
     # Overwrite specifically the data that is taken for LDV 4W demand on fleet level
-    data$fleetSizeAndComposition$fleetESdemand <- harmESdemandFV[grepl("Bus.*|.*4W|.*freight_road.*", subsectorL3)]
+    data$fleetSizeAndComposition$fleetESdemand <- harmESdemandFV[grepl("Bus.*|.*4W|.*2W|.*3W|.*freight_road.*", subsectorL3)]
   }
 
   # Base variable set that is needed to report REMIND input data and additional detailed transport data

--- a/R/reportFleetVariables.R
+++ b/R/reportFleetVariables.R
@@ -40,7 +40,7 @@ reportFleetVariables <- function(salesData, vehiclesConstrYears, helpers) {
   # different construction years
   salesData <- merge(salesData, helpers$decisionTree,
                      by = c(intersect(names(salesData), names(helpers$decisionTree))))
-  salesDataTrackedVeh <- salesData[grepl("Bus.*|.*4W|.*freight_road.*", subsectorL3)]
+  salesDataTrackedVeh <- salesData[grepl("Bus.*|.*4W|.*2W|.*3W|.*freight_road.*", subsectorL3)]
   #Interpolate the missing timesteps between 1990 and 2005
   salesDataTrackedVeh <- approx_dt(salesDataTrackedVeh, unique(vehiclesConstrYears$constrYear),
                                    "period", "value", extrapolate = TRUE)
@@ -53,7 +53,7 @@ reportFleetVariables <- function(salesData, vehiclesConstrYears, helpers) {
                                    by = eval(cols[!cols %in% c("share", "constrYear", "value")])]
   #Timesteps after 2100 need to be interpolated
   fleetData <- approx_dt(fleetData, unique(salesData$period), "period", "value", extrapolate = TRUE)
-  fleetData <- rbind(fleetData, salesData[!grepl("Bus.*|.*4W|.*freight_road.*", subsectorL3)])
+  fleetData <- rbind(fleetData, salesData[!grepl("Bus.*|.*4W|.*2W|.*3W|.*freight_road.*", subsectorL3)])
   fleetData[, variable := gsub(" sales", "", variable)]
 
   return(fleetData)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reporting package for edgeTransport
 
-R package **reporttransport**, version **1.4.0**
+R package **reporttransport**, version **1.4.1**
 
    [![R build status](https://github.com/pik-piam/reporttransport/workflows/check/badge.svg)](https://github.com/pik-piam/reporttransport/actions) [![codecov](https://codecov.io/gh/pik-piam/reporttransport/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/reporttransport) [![r-universe](https://pik-piam.r-universe.dev/badges/reporttransport)](https://pik-piam.r-universe.dev/builds)
 
@@ -41,17 +41,15 @@ In case of questions / problems please contact Johanna Hoppe <johanna.hoppe@pik-
 
 To cite package **reporttransport** in publications use:
 
-Hoppe J, Muessel J, Hagen A (2026). "reporttransport: Reporting package for edgeTransport." Version: 1.4.0, <https://github.com/pik-piam/reporttransport>.
+Hoppe J, Muessel J, Hagen A (2026). "reporttransport: Reporting package for edgeTransport - Version 1.4.1."
 
 A BibTeX entry for LaTeX users is
 
  ```latex
 @Misc{,
-  title = {reporttransport: Reporting package for edgeTransport},
+  title = {reporttransport: Reporting package for edgeTransport - Version 1.4.1},
   author = {Johanna Hoppe and Jarusch Muessel and Alex K. Hagen},
-  date = {2026-06-26},
+  date = {2026-07-13},
   year = {2026},
-  url = {https://github.com/pik-piam/reporttransport},
-  note = {Version: 1.4.0},
 }
 ```

--- a/inst/compareScenarios/cs_04_stock_and_sales.Rmd
+++ b/inst/compareScenarios/cs_04_stock_and_sales.Rmd
@@ -105,7 +105,7 @@ showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ## 2W Stock by vehicle size
 ```{r}
 tot <- "Stock|Transport|Pass|Road|LDV|Two Wheelers"
-items <- c("Stock|Transport|Pass|Road|LDV|Three Wheelers",
+items <- c(
            "Stock|Transport|Pass|Road|LDV|Two Wheelers|Motorcycle(>250cc)",
            "Stock|Transport|Pass|Road|LDV|Two Wheelers|Motorcycle(50-250cc)",
            "Stock|Transport|Pass|Road|LDV|Two Wheelers|Moped"
@@ -117,7 +117,7 @@ showAreaAndBarPlots(data, items, tot, fill = TRUE, orderVars = "user")
 ## 2W Sales by vehicle size
 ```{r}
 tot <- "Sales|Transport|Pass|Road|LDV|Two Wheelers"
-items <- c("Sales|Transport|Pass|Road|LDV|Three Wheelers",
+items <- c(
            "Sales|Transport|Pass|Road|LDV|Two Wheelers|Motorcycle(>250cc)",
            "Sales|Transport|Pass|Road|LDV|Two Wheelers|Motorcycle(50-250cc)",
            "Sales|Transport|Pass|Road|LDV|Two Wheelers|Moped"


### PR DESCRIPTION
## Purpose of this PR
While the SA-version ran smoothly, the REMIND reporting failed through this [PR ](https://github.com/pik-piam/reporttransport/blob/a39679f08858e5a04f19ff888fde6c8c45f80c1f/R/reportBaseVarSet.R#L23)- [see discussion on Mattermost](https://mattermost.pik-potsdam.de/rd3/pl/uetcqbt9ebb7tx7ziz18zw5mxo)


The issue is that REMIND asks for a harmonization with REMIND ES demand in the reporting. This harmonization at the CES level probably failed because 2-3W were [also](https://github.com/pik-piam/reporttransport/blob/a39679f08858e5a04f19ff888fde6c8c45f80c1f/R/reportBaseVarSet.R#L23) included in the edgeT reporting but were [not ](https://github.com/pik-piam/reporttransport/blob/a39679f08858e5a04f19ff888fde6c8c45f80c1f/R/harmonizeREMINDvsEDGETenergyServiceDemand.R#L24) considered for harmonization.

## Checklist:

- [X] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 
`/p/projects/edget/PRchangeLog/20260713_fixed2-3W`


There were no differences introduced, as supposed to be: 

<img width="336" height="430" alt="image" src="https://github.com/user-attachments/assets/e3428817-4b4a-43d5-b4f1-aafd18f2d913" />
